### PR TITLE
Remove in_use asset status variant

### DIFF
--- a/src/app/(dashboard)/assets/page.tsx
+++ b/src/app/(dashboard)/assets/page.tsx
@@ -46,7 +46,7 @@ interface AssetFromBackend {
   name: string;
   type?: string | null;
   description?: string;
-  status: "available" | "in_use" | "maintenance" | "retired";
+  status: "available" | "maintenance" | "retired";
   project_id?: string;
   created_at: string;
   updated_at: string;
@@ -107,7 +107,6 @@ const transformBackendAsset = (backendAsset: AssetFromBackend): Asset => {
 const capitalizeStatus = (status: string): string => {
   const statusMap: Record<string, string> = {
     available: "Operational",
-    in_use: "In Use",
     maintenance: "Maintenance",
     retired: "Retired",
   };
@@ -130,12 +129,6 @@ const formatStatusForDisplay = (status: string) => {
       sidebarClassName:
         "text-emerald-300 bg-emerald-500/20 border-emerald-500/30",
       dotColor: "bg-emerald-500",
-    },
-    "In Use": {
-      label: "In Use",
-      className: "text-blue-700 border-blue-200 bg-blue-50",
-      sidebarClassName: "text-blue-300 bg-blue-500/20 border-blue-500/30",
-      dotColor: "bg-blue-500",
     },
     Maintenance: {
       label: "Maintenance",
@@ -322,12 +315,11 @@ export default function AssetsTable() {
         }
 
         if (sortField === "assetStatus") {
-          // Custom status order: Operational > In Use > Maintenance > Retired
+          // Custom status order: Operational > Maintenance > Retired
           const statusOrder: Record<string, number> = {
             Operational: 0,
-            "In Use": 1,
-            Maintenance: 2,
-            Retired: 3,
+            Maintenance: 1,
+            Retired: 2,
           };
           const aOrder = statusOrder[a.assetStatus] ?? 99;
           const bOrder = statusOrder[b.assetStatus] ?? 99;

--- a/src/components/forms/CreateAssetForm.tsx
+++ b/src/components/forms/CreateAssetForm.tsx
@@ -50,7 +50,7 @@ interface AssetCreateRequest {
   name: string;
   asset_type: string;
   description?: string;
-  status: "available" | "in_use" | "maintenance" | "retired";
+  status: "available" | "maintenance" | "retired";
   project_id?: string;
   location?: string;
   poc?: string;
@@ -62,10 +62,9 @@ interface AssetCreateRequest {
 // ===== HELPER FUNCTIONS =====
 const mapFrontendStatusToBackend = (
   status: string
-): "available" | "in_use" | "maintenance" | "retired" => {
-  const statusMap: Record<string, "available" | "in_use" | "maintenance" | "retired"> = {
+): "available" | "maintenance" | "retired" => {
+  const statusMap: Record<string, "available" | "maintenance" | "retired"> = {
     Operational: "available",
-    "In Use": "in_use",
     Maintenance: "maintenance",
     "Out of Service": "retired",
   };
@@ -404,18 +403,6 @@ const AssetModal: React.FC<AssetModalProps> = ({ isOpen, onClose, onSave }) => {
                   onClick={() => handleStatusChange("Operational")}
                 >
                   Operational
-                </button>
-                <button
-                  type="button"
-                  className={cn(
-                    "px-4 py-2 rounded-md transition text-sm",
-                    asset.assetStatus === "In Use"
-                      ? "bg-blue-100 text-blue-800 font-medium border-2 border-blue-500"
-                      : "bg-gray-100 hover:bg-gray-200 border-2 border-transparent"
-                  )}
-                  onClick={() => handleStatusChange("In Use")}
-                >
-                  In Use
                 </button>
                 <button
                   type="button"

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -9,7 +9,7 @@ export type BookingStatus =
   | "cancelled"
   | "denied";
 
-export type AssetStatus = "available" | "in_use" | "maintenance" | "retired";
+export type AssetStatus = "available" | "maintenance" | "retired";
 
 export type UserRole = "admin" | "manager" | "subcontractor";
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Removed "In Use" status option from asset management; assets now support only "Operational", "Maintenance", and "Retired" statuses.
  * Improved maintenance date handling: status automatically switches to "Maintenance" when maintenance windows overlap the current date.
  * Updated asset creation and modification forms to reflect revised status options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->