### PR TITLE
Add one-time token capture to password reset components

### DIFF
--- a/src/app/(auth)/reset-password/page.tsx
+++ b/src/app/(auth)/reset-password/page.tsx
@@ -59,7 +59,7 @@ function ResetPasswordForm() {
 
   // 3. Validate Token Presence
   useEffect(() => {
-    if (!token) setTokenValid(false);
+    setTokenValid(Boolean(token));
   }, [token]);
 
   // 4. Strict Password Validation (Restored from your original code)

--- a/src/app/(auth)/reset-password/page.tsx
+++ b/src/app/(auth)/reset-password/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, Suspense } from "react";
+import { useState, useEffect, Suspense, useRef } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -34,7 +34,8 @@ function ResetPasswordForm() {
     message?: string;
   }>({ type: "idle" });
   const [tokenValid, setTokenValid] = useState(true);
-  const [token, setToken] = useState<string | null>(queryToken);
+  const [token, setToken] = useState<string | null>(null);
+  const hasCapturedToken = useRef(false);
 
   // 1. Force logout on mount
   useEffect(() => {
@@ -43,12 +44,16 @@ function ResetPasswordForm() {
 
   // 2. Capture token once, then scrub it from the URL to reduce leakage
   useEffect(() => {
+    if (hasCapturedToken.current) return;
+
     if (queryToken) {
       setToken(queryToken);
+      hasCapturedToken.current = true;
       window.history.replaceState({}, "", window.location.pathname);
       return;
     }
 
+    hasCapturedToken.current = true;
     setToken(null);
   }, [queryToken]);
 

--- a/src/app/(auth)/set-password/page.tsx
+++ b/src/app/(auth)/set-password/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, Suspense } from "react";
+import { useState, useEffect, Suspense, useRef } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -34,7 +34,8 @@ function SetPasswordForm() {
     message?: string;
   }>({ type: "idle" });
   const [tokenValid, setTokenValid] = useState(true);
-  const [token, setToken] = useState<string | null>(queryToken);
+  const [token, setToken] = useState<string | null>(null);
+  const hasCapturedToken = useRef(false);
 
   // 1. Force logout on mount
   // useEffect(() => {
@@ -43,12 +44,16 @@ function SetPasswordForm() {
 
   // 2. Capture token once, then scrub it from the URL to reduce leakage
   useEffect(() => {
+    if (hasCapturedToken.current) return;
+
     if (queryToken) {
       setToken(queryToken);
+      hasCapturedToken.current = true;
       window.history.replaceState({}, "", window.location.pathname);
       return;
     }
 
+    hasCapturedToken.current = true;
     setToken(null);
   }, [queryToken]);
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Authentication token capture now occurs only once in the reset/set-password flows and the token is automatically removed from the URL to reduce risk of accidental exposure during navigation or sharing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->