### PR TITLE
Update subcontractor name derivation to use first and last names

### DIFF
--- a/src/app/(dashboard)/home/page.tsx
+++ b/src/app/(dashboard)/home/page.tsx
@@ -492,7 +492,13 @@ export default function HomePage() {
                           assetName && assetCode ? `(${assetCode})` : "";
 
                         const subName = booking.subcontractor
-                          ? `${booking.subcontractor.first_name} ${booking.subcontractor.last_name}`.trim()
+                          ? [
+                              booking.subcontractor?.first_name || "",
+                              booking.subcontractor?.last_name || "",
+                            ]
+                              .filter(Boolean)
+                              .join(" ")
+                              .trim()
                           : "";
 
                         const assignee = booking.subcontractor_id

--- a/src/app/(dashboard)/home/page.tsx
+++ b/src/app/(dashboard)/home/page.tsx
@@ -491,11 +491,9 @@ export default function HomePage() {
                         const assetCodeSuffix =
                           assetName && assetCode ? `(${assetCode})` : "";
 
-                        const subName =
-                          booking.subcontractor?.company_name ||
-                          (booking.subcontractor
-                            ? `${booking.subcontractor.first_name} ${booking.subcontractor.last_name}`.trim()
-                            : "");
+                        const subName = booking.subcontractor
+                          ? `${booking.subcontractor.first_name} ${booking.subcontractor.last_name}`.trim()
+                          : "";
 
                         const assignee = booking.subcontractor_id
                           ? subName || "Unknown Subcontractor"

--- a/src/components/bookings/BookingsPage.tsx
+++ b/src/components/bookings/BookingsPage.tsx
@@ -52,11 +52,9 @@ const transformBookingToLegacyFormat = (
   const managerName = booking.manager
     ? `${booking.manager.first_name} ${booking.manager.last_name}`
     : "Unknown";
-  const subName =
-    booking.subcontractor?.company_name ||
-    (booking.subcontractor
-      ? `${booking.subcontractor.first_name} ${booking.subcontractor.last_name}`
-      : "");
+  const subName = booking.subcontractor
+    ? `${booking.subcontractor.first_name} ${booking.subcontractor.last_name}`.trim()
+    : "";
 
   const createdByName =
     booking.created_by_name ||

--- a/src/components/bookings/BookingsPage.tsx
+++ b/src/components/bookings/BookingsPage.tsx
@@ -31,6 +31,9 @@ const calculateDuration = (startTime: string, endTime: string): number => {
   return end - start;
 };
 
+const getSafeString = (value: unknown): string =>
+  typeof value === "string" ? value : "";
+
 const transformBookingToLegacyFormat = (
   booking: ApiBooking,
 ): TransformedBooking => {
@@ -53,7 +56,13 @@ const transformBookingToLegacyFormat = (
     ? `${booking.manager.first_name} ${booking.manager.last_name}`
     : "Unknown";
   const subName = booking.subcontractor
-    ? `${booking.subcontractor.first_name} ${booking.subcontractor.last_name}`.trim()
+    ? [
+        getSafeString(booking.subcontractor.first_name),
+        getSafeString(booking.subcontractor.last_name),
+      ]
+        .filter(Boolean)
+        .join(" ")
+        .trim()
     : "";
 
   const createdByName =

--- a/src/components/forms/InviteSubForm.tsx
+++ b/src/components/forms/InviteSubForm.tsx
@@ -629,7 +629,7 @@ const SubFormModal: React.FC<ContractorModalProps> = ({
             </Button>
             <Button
               type="submit"
-              className="w-full bg-black text-white hover:bg-gray-800 sm:w-auto !whitespace-normal text-center leading-tight"
+              className="w-full bg-black text-white hover:bg-gray-800 sm:w-auto"
               disabled={isSubmitting || !emailChecked}
             >
               {isSubmitting ? (
@@ -659,10 +659,7 @@ const SubFormModal: React.FC<ContractorModalProps> = ({
               ) : existingSubcontractor ? (
                 "Add to Project"
               ) : (
-                <>
-                  <span className="sm:hidden">Create & Add</span>
-                  <span className="hidden sm:inline">Create & Add to Project</span>
-                </>
+                "Create & Add to Project"
               )}
             </Button>
           </div>

--- a/src/lib/multicalendarHelpers.ts
+++ b/src/lib/multicalendarHelpers.ts
@@ -109,12 +109,13 @@ export function convertBookingToCalendarEvent(
       .filter(Boolean)
       .join(" ")
       .trim() || "Manager";
-  const subName =
-    getString(subcontractor?.company_name) ||
-    [getString(subcontractor?.first_name), getString(subcontractor?.last_name)]
-      .filter(Boolean)
-      .join(" ")
-      .trim();
+  const subName = [
+    getString(subcontractor?.first_name),
+    getString(subcontractor?.last_name),
+  ]
+    .filter(Boolean)
+    .join(" ")
+    .trim();
   const subcontractorId = getId(raw.subcontractor_id);
 
   const createdBy = isRecord(raw.created_by) ? raw.created_by : undefined;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Subcontractor display now consistently shows first and last names for bookings and calendar views, falling back to "Unknown Subcontractor" when name parts are missing.
* **Style**
  * Simplified invite form submit button label to a single, consistent text and reduced its extra styling for a cleaner appearance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->