### PR TITLE
Remove asset code suffix and add booking datetime validation

### DIFF
--- a/src/app/(dashboard)/home/page.tsx
+++ b/src/app/(dashboard)/home/page.tsx
@@ -510,11 +510,8 @@ export default function HomePage() {
                           : "Unknown Manager";
 
                         const assetName = booking.asset?.name?.trim();
-                        const assetCode = booking.asset?.asset_code?.trim();
                         const assetLabel =
                           assetName || booking.asset_id || "Unspecified asset";
-                        const assetCodeSuffix =
-                          assetName && assetCode ? `(${assetCode})` : "";
 
                         const subName = booking.subcontractor
                           ? [
@@ -629,11 +626,6 @@ export default function HomePage() {
                                 <span className="min-w-0 flex-1 text-blue-700 font-semibold truncate">
                                   {assetLabel}
                                 </span>
-                                {assetCodeSuffix && (
-                                  <span className="hidden text-[10px] text-slate-400 font-medium lg:inline">
-                                    {assetCodeSuffix}
-                                  </span>
-                                )}
                               </div>
 
                               <div className="flex min-w-0 items-center gap-1 text-xs font-medium text-slate-400">

--- a/src/components/forms/CreateBookingForm.tsx
+++ b/src/components/forms/CreateBookingForm.tsx
@@ -758,6 +758,31 @@ export function CreateBookingForm({
       return;
     }
 
+    const buildBookingDateTime = (date: Date, time: Date) => {
+      const merged = new Date(date);
+      merged.setHours(time.getHours(), time.getMinutes(), 0, 0);
+      return merged;
+    };
+
+    const bookingStartDt = buildBookingDateTime(selectedDate, customStartTime);
+    const bookingEndDt = buildBookingDateTime(selectedDate, customEndTime);
+
+    if (bookingStartDt.getTime() < Date.now()) {
+      dispatchAsync({
+        type: "SET_ERROR",
+        error: "Bookings cannot be created in the past",
+      });
+      return;
+    }
+
+    if (bookingEndDt <= bookingStartDt) {
+      dispatchAsync({
+        type: "SET_ERROR",
+        error: "End time must be later than start time",
+      });
+      return;
+    }
+
     if (!title.trim()) {
       dispatchAsync({
         type: "SET_ERROR",
@@ -783,8 +808,8 @@ export function CreateBookingForm({
       dispatchAsync({ type: "SET_SUBMITTING", value: true });
 
       const bookingDate = format(selectedDate, "yyyy-MM-dd");
-      const startTimeFormatted = format(customStartTime, "HH:mm:ss");
-      const endTimeFormatted = format(customEndTime, "HH:mm:ss");
+      const startTimeFormatted = format(bookingStartDt, "HH:mm:ss");
+      const endTimeFormatted = format(bookingEndDt, "HH:mm:ss");
 
       const normalizeTime = (timeValue: string) =>
         (timeValue || "").split(":").slice(0, 2).join(":");

--- a/src/components/forms/CreateBookingForm.tsx
+++ b/src/components/forms/CreateBookingForm.tsx
@@ -750,14 +750,6 @@ export function CreateBookingForm({
       return;
     }
 
-    if (customEndTime <= customStartTime) {
-      dispatchAsync({
-        type: "SET_ERROR",
-        error: "End time must be later than start time",
-      });
-      return;
-    }
-
     const buildBookingDateTime = (date: Date, time: Date) => {
       const merged = new Date(date);
       merged.setHours(time.getHours(), time.getMinutes(), 0, 0);
@@ -767,18 +759,18 @@ export function CreateBookingForm({
     const bookingStartDt = buildBookingDateTime(selectedDate, customStartTime);
     const bookingEndDt = buildBookingDateTime(selectedDate, customEndTime);
 
-    if (bookingStartDt.getTime() < Date.now()) {
-      dispatchAsync({
-        type: "SET_ERROR",
-        error: "Bookings cannot be created in the past",
-      });
-      return;
-    }
-
     if (bookingEndDt <= bookingStartDt) {
       dispatchAsync({
         type: "SET_ERROR",
         error: "End time must be later than start time",
+      });
+      return;
+    }
+
+    if (bookingStartDt.getTime() < Date.now()) {
+      dispatchAsync({
+        type: "SET_ERROR",
+        error: "Bookings cannot be created in the past",
       });
       return;
     }

--- a/src/components/forms/RescheduleBookingForm.tsx
+++ b/src/components/forms/RescheduleBookingForm.tsx
@@ -208,6 +208,13 @@ export default function RescheduleBookingForm({
         0,
       );
 
+      const endDt = new Date(selectedDate);
+      endDt.setHours(parseInt(endHour, 10), parseInt(endMinute, 10), 0, 0);
+
+      if (endDt.getTime() <= startDt.getTime()) {
+        throw new Error("End time must be later than start time");
+      }
+
       if (startDt.getTime() < Date.now()) {
         throw new Error("Bookings cannot be made in the past");
       }

--- a/src/components/forms/RescheduleBookingForm.tsx
+++ b/src/components/forms/RescheduleBookingForm.tsx
@@ -200,6 +200,18 @@ export default function RescheduleBookingForm({
         throw new Error("Please fill in all date and time fields");
       }
 
+      const startDt = new Date(selectedDate);
+      startDt.setHours(
+        parseInt(startHour, 10),
+        parseInt(startMinute, 10),
+        0,
+        0,
+      );
+
+      if (startDt.getTime() < Date.now()) {
+        throw new Error("Bookings cannot be made in the past");
+      }
+
       // Prepare Payload
       const payload = {
         booking_date: format(selectedDate, "yyyy-MM-dd"),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Bookings can no longer be created with past start times or end times that occur before the start time.
  * Rescheduling now prevents selecting past dates.

* **Changes**
  * Removed asset code suffix from booking item display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->