### PR TITLE
Add Site Plans feature to dashboard

### DIFF
--- a/src/app/(dashboard)/home/page.tsx
+++ b/src/app/(dashboard)/home/page.tsx
@@ -32,6 +32,7 @@ import {
   groupBookingsByMonth,
 } from "@/lib/bookingHelpers";
 import type { ApiBooking, ApiProject } from "@/types";
+import { SitePlansSection } from "@/components/site-plans/SitePlansSection";
 import type { LucideIcon } from "lucide-react";
 import useSWR from "swr";
 import { swrFetcher, SWR_CONFIG } from "@/lib/swr";
@@ -88,6 +89,8 @@ export default function HomePage() {
   const { user } = useAuth();
   const router = useRouter();
   const isSubcontractorUser = user?.role === "subcontractor";
+  const canEditSitePlans =
+    user?.role === "admin" || user?.role === "manager";
 
   const [selectedProject, setSelectedProject] = useState<ApiProject | null>(
     null,
@@ -665,7 +668,30 @@ export default function HomePage() {
             </div>
           </div>
 
-          {/* RIGHT COL: Today's Schedule */}
+          {/* RIGHT COL: Site Plans */}
+          <div className="col-span-12 lg:col-span-4 space-y-4">
+            {projectId ? (
+              <SitePlansSection
+                projectId={projectId}
+                canEdit={canEditSitePlans}
+              />
+            ) : (
+              <>
+                <div className="flex justify-between items-center mb-2">
+                  <h2 className="text-xl font-bold text-slate-900">
+                    Site Plans
+                  </h2>
+                </div>
+                <div className="bg-white rounded-2xl shadow-sm border border-slate-100 min-h-[400px] flex items-center justify-center">
+                  <p className="text-sm text-slate-400">
+                    Select a project to view site plans
+                  </p>
+                </div>
+              </>
+            )}
+          </div>
+
+          {/* RIGHT COL: Today's Schedule (commented out — replaced by Site Plans)
           <div className="col-span-12 lg:col-span-4 space-y-4">
             <div className="flex justify-between items-center mb-2">
               <h2 className="text-xl font-bold text-slate-900">
@@ -699,6 +725,7 @@ export default function HomePage() {
               </div>
             </div>
           </div>
+          */}
         </div>
       </div>
     </div>

--- a/src/app/(dashboard)/home/page.tsx
+++ b/src/app/(dashboard)/home/page.tsx
@@ -691,41 +691,6 @@ export default function HomePage() {
             )}
           </div>
 
-          {/* RIGHT COL: Today's Schedule (commented out — replaced by Site Plans)
-          <div className="col-span-12 lg:col-span-4 space-y-4">
-            <div className="flex justify-between items-center mb-2">
-              <h2 className="text-xl font-bold text-slate-900">
-                Today&apos;s Schedule
-              </h2>
-            </div>
-
-            <div className="bg-white rounded-2xl shadow-sm p-6 min-h-[400px] border border-slate-100">
-              <SimpleCalendar />
-              <div className="mt-6 space-y-4 relative pl-4 border-l-2 border-slate-100">
-                <div className="absolute top-0 left-[-5px] h-2.5 w-2.5 rounded-full bg-slate-300 border-2 border-white"></div>
-                <div className="bg-slate-50 p-3 rounded-lg border border-slate-100">
-                  <div className="text-xs text-slate-400 font-bold mb-1">
-                    08:00 AM
-                  </div>
-                  <div className="text-sm font-bold text-slate-800">
-                    Site Opening
-                  </div>
-                </div>
-                <div className="bg-slate-50 p-3 rounded-lg border border-slate-100">
-                  <div className="text-xs text-slate-400 font-bold mb-1">
-                    10:30 AM
-                  </div>
-                  <div className="text-sm font-bold text-slate-800">
-                    Material Delivery
-                  </div>
-                  <div className="text-xs text-slate-500 mt-1">
-                    Drywall panels - Bay 4
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-          */}
         </div>
       </div>
     </div>
@@ -798,42 +763,3 @@ const EmptyBookingsState = () => (
   </div>
 );
 
-const SimpleCalendar = () => {
-  const days = ["M", "T", "W", "T", "F", "S", "S"];
-  const today = new Date().getDate();
-  const startDay = Math.max(1, today - 3);
-  const displayDates = Array.from({ length: 7 }, (_, i) => startDay + i);
-
-  return (
-    <div className="text-xs w-full">
-      <div className="flex justify-between items-center mb-4 border-b border-slate-100 pb-2">
-        <span className="font-bold text-slate-800 text-sm">
-          {new Date().toLocaleString("default", {
-            month: "long",
-            year: "numeric",
-          })}
-        </span>
-        <ChevronDown className="h-4 w-4 text-slate-400" />
-      </div>
-      <div className="grid grid-cols-7 gap-1 text-center mb-2 text-slate-400 font-medium">
-        {days.map((d, i) => (
-          <div key={i}>{d}</div>
-        ))}
-      </div>
-      <div className="grid grid-cols-7 gap-1 text-center">
-        {displayDates.map((d) => (
-          <div
-            key={d}
-            className={`h-8 w-8 mx-auto flex items-center justify-center rounded-lg font-medium transition-colors ${
-              d === today
-                ? `${PALETTE.darkNavy} text-white shadow-md`
-                : "text-slate-600 hover:bg-slate-100 cursor-pointer"
-            }`}
-          >
-            {d}
-          </div>
-        ))}
-      </div>
-    </div>
-  );
-};

--- a/src/app/api/proxy/route.ts
+++ b/src/app/api/proxy/route.ts
@@ -81,9 +81,13 @@ async function proxyToBackend(
   const query = params.toString();
   const targetUrl = `${process.env.NEXT_PUBLIC_API_URL}${apiPath}${query ? `?${query}` : ""}`;
 
+  // Detect multipart uploads to pass through correctly
+  const incomingContentType = request.headers.get("content-type") || "";
+  const isMultipart = incomingContentType.includes("multipart/form-data");
+
   // Build fetch options
   const headers: Record<string, string> = {
-    "Content-Type": "application/json",
+    "Content-Type": isMultipart ? incomingContentType : "application/json",
   };
   if (tokens.access) {
     headers.Authorization = `Bearer ${tokens.access}`;
@@ -92,12 +96,28 @@ async function proxyToBackend(
   const fetchOpts: RequestInit = { method, headers };
 
   if (!["GET", "HEAD", "DELETE"].includes(method)) {
-    try {
-      const body = await request.text();
-      if (body) fetchOpts.body = body;
-    } catch (error: unknown) {
-      reportError(error, "proxy route: failed to read request body", "server");
-      /* no body */
+    if (isMultipart) {
+      try {
+        fetchOpts.body = await request.arrayBuffer();
+      } catch (error: unknown) {
+        reportError(
+          error,
+          "proxy route: failed to read multipart request body",
+          "server",
+        );
+      }
+    } else {
+      try {
+        const body = await request.text();
+        if (body) fetchOpts.body = body;
+      } catch (error: unknown) {
+        reportError(
+          error,
+          "proxy route: failed to read request body",
+          "server",
+        );
+        /* no body */
+      }
     }
   }
 
@@ -145,6 +165,29 @@ async function proxyToBackend(
     res.cookies.set("accessToken", "", { path: "/", maxAge: 0 });
     res.cookies.set("refreshToken", "", { path: "/", maxAge: 0 });
     return res;
+  }
+
+  // Handle binary responses (images, PDFs, raw files)
+  const respContentType = response.headers.get("content-type") || "";
+  const isBinaryResponse =
+    respContentType.startsWith("image/") ||
+    respContentType.startsWith("application/pdf") ||
+    respContentType.includes("octet-stream");
+
+  if (isBinaryResponse) {
+    const buffer = await response.arrayBuffer();
+    const responseHeaders: Record<string, string> = {
+      "Content-Type": respContentType,
+    };
+    const cacheControl = response.headers.get("cache-control");
+    if (cacheControl) responseHeaders["Cache-Control"] = cacheControl;
+    const contentDisposition = response.headers.get("content-disposition");
+    if (contentDisposition)
+      responseHeaders["Content-Disposition"] = contentDisposition;
+    return new NextResponse(buffer, {
+      status: response.status,
+      headers: responseHeaders,
+    });
   }
 
   const data = await response.json().catch(() => null);

--- a/src/app/api/proxy/route.ts
+++ b/src/app/api/proxy/route.ts
@@ -28,6 +28,48 @@ async function tryRefresh(
   }
 }
 
+/** Build a NextResponse from a backend Response, preserving binary content.
+ *  Optionally sets cookies on the resulting response (used after token refresh). */
+async function buildNextResponse(
+  response: Response,
+  cookiesToSet?: Array<Parameters<NextResponse["cookies"]["set"]>>,
+): Promise<NextResponse> {
+  const respContentType = response.headers.get("content-type") || "";
+  const isBinary =
+    respContentType.startsWith("image/") ||
+    respContentType.startsWith("application/pdf") ||
+    respContentType.includes("octet-stream");
+
+  let res: NextResponse;
+
+  if (isBinary) {
+    const buffer = await response.arrayBuffer();
+    const responseHeaders: Record<string, string> = {
+      "Content-Type": respContentType,
+    };
+    const cacheControl = response.headers.get("cache-control");
+    if (cacheControl) responseHeaders["Cache-Control"] = cacheControl;
+    const contentDisposition = response.headers.get("content-disposition");
+    if (contentDisposition)
+      responseHeaders["Content-Disposition"] = contentDisposition;
+    res = new NextResponse(buffer, {
+      status: response.status,
+      headers: responseHeaders,
+    });
+  } else {
+    const data = await response.json().catch(() => null);
+    res = NextResponse.json(data, { status: response.status });
+  }
+
+  if (cookiesToSet) {
+    for (const args of cookiesToSet) {
+      res.cookies.set(...args);
+    }
+  }
+
+  return res;
+}
+
 const PUBLIC_AUTH_PATHS = ["/auth/forgot-password", "/auth/reset-password"];
 
 const PUBLIC_AUTH_LIMIT = 8;
@@ -105,6 +147,10 @@ async function proxyToBackend(
           "proxy route: failed to read multipart request body",
           "server",
         );
+        return NextResponse.json(
+          { message: "Failed to read request body" },
+          { status: 400 },
+        );
       }
     } else {
       try {
@@ -132,29 +178,24 @@ async function proxyToBackend(
       headers.Authorization = `Bearer ${newTokens.access_token}`;
       response = await fetch(targetUrl, { ...fetchOpts, headers });
 
-      // Return response with updated cookies
-      const data = await response.json().catch(() => null);
-      const res = NextResponse.json(data, { status: response.status });
-
-      res.cookies.set("accessToken", newTokens.access_token, {
+      const cookieBase = {
         httpOnly: true,
         secure: process.env.NODE_ENV === "production",
-        sameSite: "lax",
+        sameSite: "lax" as const,
         path: "/",
-        maxAge: 60 * 60 * 24,
-      });
-
+      };
+      const cookiesToSet: Array<Parameters<NextResponse["cookies"]["set"]>> = [
+        ["accessToken", newTokens.access_token, { ...cookieBase, maxAge: 60 * 60 * 24 }],
+      ];
       if (newTokens.refresh_token) {
-        res.cookies.set("refreshToken", newTokens.refresh_token, {
-          httpOnly: true,
-          secure: process.env.NODE_ENV === "production",
-          sameSite: "lax",
-          path: "/",
-          maxAge: 60 * 60 * 24 * 7,
-        });
+        cookiesToSet.push([
+          "refreshToken",
+          newTokens.refresh_token,
+          { ...cookieBase, maxAge: 60 * 60 * 24 * 7 },
+        ]);
       }
 
-      return res;
+      return buildNextResponse(response, cookiesToSet);
     }
 
     // Refresh failed — clear everything
@@ -167,31 +208,7 @@ async function proxyToBackend(
     return res;
   }
 
-  // Handle binary responses (images, PDFs, raw files)
-  const respContentType = response.headers.get("content-type") || "";
-  const isBinaryResponse =
-    respContentType.startsWith("image/") ||
-    respContentType.startsWith("application/pdf") ||
-    respContentType.includes("octet-stream");
-
-  if (isBinaryResponse) {
-    const buffer = await response.arrayBuffer();
-    const responseHeaders: Record<string, string> = {
-      "Content-Type": respContentType,
-    };
-    const cacheControl = response.headers.get("cache-control");
-    if (cacheControl) responseHeaders["Cache-Control"] = cacheControl;
-    const contentDisposition = response.headers.get("content-disposition");
-    if (contentDisposition)
-      responseHeaders["Content-Disposition"] = contentDisposition;
-    return new NextResponse(buffer, {
-      status: response.status,
-      headers: responseHeaders,
-    });
-  }
-
-  const data = await response.json().catch(() => null);
-  return NextResponse.json(data, { status: response.status });
+  return buildNextResponse(response);
 }
 
 export async function GET(req: Request) {

--- a/src/components/site-plans/SitePlanUploadDialog.tsx
+++ b/src/components/site-plans/SitePlanUploadDialog.tsx
@@ -14,6 +14,7 @@ import { AlertCircle, Loader2, RefreshCw, Upload } from "lucide-react";
 import api from "@/lib/api";
 import type { FileUploadResponse, SitePlan } from "@/types";
 import { getApiErrorMessage } from "@/types";
+import { toProxyUrl, validateSitePlanFile } from "@/lib/sitePlanUtils";
 
 interface SitePlanUploadDialogProps {
   isOpen: boolean;
@@ -21,11 +22,6 @@ interface SitePlanUploadDialogProps {
   projectId: string;
   existingPlan?: SitePlan | null;
   onSuccess: (plan: SitePlan) => void;
-}
-
-function toProxyUrl(backendUrl: string): string {
-  const path = backendUrl.replace(/^\/api/, "");
-  return `/api/proxy?path=${encodeURIComponent(path)}`;
 }
 
 export function SitePlanUploadDialog({
@@ -66,6 +62,12 @@ export function SitePlanUploadDialog({
     const file = e.target.files?.[0];
     if (!file) return;
     if (fileInputRef.current) fileInputRef.current.value = "";
+
+    const validationError = validateSitePlanFile(file);
+    if (validationError) {
+      setError(validationError);
+      return;
+    }
 
     setError(null);
     setUploading(true);

--- a/src/components/site-plans/SitePlanUploadDialog.tsx
+++ b/src/components/site-plans/SitePlanUploadDialog.tsx
@@ -1,0 +1,272 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { AlertCircle, Loader2, RefreshCw, Upload } from "lucide-react";
+import api from "@/lib/api";
+import type { FileUploadResponse, SitePlan } from "@/types";
+import { getApiErrorMessage } from "@/types";
+
+interface SitePlanUploadDialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+  projectId: string;
+  existingPlan?: SitePlan | null;
+  onSuccess: (plan: SitePlan) => void;
+}
+
+function toProxyUrl(backendUrl: string): string {
+  const path = backendUrl.replace(/^\/api/, "");
+  return `/api/proxy?path=${encodeURIComponent(path)}`;
+}
+
+export function SitePlanUploadDialog({
+  isOpen,
+  onClose,
+  projectId,
+  existingPlan,
+  onSuccess,
+}: SitePlanUploadDialogProps) {
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const isUpdating = !!existingPlan;
+
+  const [uploading, setUploading] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [newFileId, setNewFileId] = useState<string | null>(null);
+  const [newPreviewUrl, setNewPreviewUrl] = useState<string | null>(null);
+  const [title, setTitle] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (isOpen) {
+      setUploading(false);
+      setSubmitting(false);
+      setNewFileId(null);
+      setNewPreviewUrl(null);
+      setTitle(existingPlan?.title ?? "");
+      setError(null);
+    }
+  }, [isOpen, existingPlan?.title]);
+
+  const existingPreviewUrl = existingPlan
+    ? toProxyUrl(existingPlan.file.preview_url)
+    : null;
+
+  const displayPreviewUrl = newPreviewUrl ?? existingPreviewUrl;
+
+  const handleFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    if (fileInputRef.current) fileInputRef.current.value = "";
+
+    setError(null);
+    setUploading(true);
+
+    try {
+      const formData = new FormData();
+      formData.append("file", file);
+
+      const res = await api.post<FileUploadResponse>(
+        "/files/upload",
+        formData,
+        {
+          // Remove Content-Type so the browser sets multipart/form-data with the
+          // correct boundary automatically. The axios instance default of
+          // "application/json" would otherwise serialize FormData to JSON.
+          transformRequest: (
+            data: unknown,
+            headers?: Record<string, string>,
+          ) => {
+            if (headers) {
+              delete headers["Content-Type"];
+              delete headers["content-type"];
+            }
+            return data;
+          },
+        },
+      );
+
+      const { file_id, suggested_title, preview_url } = res.data;
+      setNewFileId(file_id);
+      if (!isUpdating || !title) setTitle(suggested_title);
+      setNewPreviewUrl(toProxyUrl(preview_url));
+    } catch (err) {
+      setError(getApiErrorMessage(err, "Failed to upload file"));
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  const handleSubmit = async () => {
+    if (!title.trim()) {
+      setError("Title is required");
+      return;
+    }
+
+    setError(null);
+    setSubmitting(true);
+
+    try {
+      let plan: SitePlan;
+      if (isUpdating && existingPlan) {
+        const payload: { title: string; file_id?: string } = {
+          title: title.trim(),
+        };
+        if (newFileId) payload.file_id = newFileId;
+        const res = await api.patch<SitePlan>(
+          `/site-plans/${existingPlan.id}`,
+          payload,
+        );
+        plan = res.data;
+      } else {
+        const res = await api.post<SitePlan>("/site-plans/", {
+          title: title.trim(),
+          file_id: newFileId,
+          project_id: projectId,
+        });
+        plan = res.data;
+      }
+      onSuccess(plan);
+    } catch (err) {
+      setError(getApiErrorMessage(err, "Failed to save site plan"));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const canSubmit =
+    (isUpdating || !!newFileId) && !!title.trim() && !uploading && !submitting;
+
+  return (
+    <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
+      <DialogContent className="w-[calc(100vw-1rem)] max-w-md bg-white p-0 gap-0 border-slate-200 shadow-2xl overflow-hidden">
+        <DialogHeader className="px-6 pt-6 pb-4 border-b border-slate-100 pr-14">
+          <DialogTitle className="text-lg font-semibold text-slate-900">
+            {isUpdating ? "Update Site Plan" : "Upload Site Plan"}
+          </DialogTitle>
+        </DialogHeader>
+
+        <div className="px-6 py-6 space-y-5">
+          {/* Preview / file picker area */}
+          {displayPreviewUrl ? (
+            <div className="space-y-3">
+              <div className="relative w-full aspect-video bg-slate-100 rounded-xl overflow-hidden border border-slate-200">
+                {uploading && (
+                  <div className="absolute inset-0 bg-white/80 flex items-center justify-center z-10">
+                    <Loader2 className="h-6 w-6 animate-spin text-slate-400" />
+                  </div>
+                )}
+                {/* eslint-disable-next-line @next/next/no-img-element */}
+                <img
+                  src={displayPreviewUrl}
+                  alt="Site plan preview"
+                  className="w-full h-full object-contain"
+                />
+              </div>
+              <button
+                type="button"
+                onClick={() => fileInputRef.current?.click()}
+                disabled={uploading || submitting}
+                className="flex items-center gap-1.5 text-xs text-slate-500 hover:text-slate-700 disabled:opacity-50 transition-colors"
+              >
+                <RefreshCw className="h-3 w-3" />
+                {isUpdating ? "Replace file" : "Choose a different file"}
+              </button>
+            </div>
+          ) : !uploading ? (
+            <button
+              type="button"
+              onClick={() => fileInputRef.current?.click()}
+              className="w-full border-2 border-dashed border-slate-200 rounded-xl p-8 flex flex-col items-center justify-center gap-3 text-slate-500 hover:border-slate-400 hover:text-slate-700 transition-colors cursor-pointer"
+            >
+              <Upload className="h-8 w-8 opacity-60" />
+              <div className="text-center">
+                <p className="font-medium text-sm">Click to select a file</p>
+                <p className="text-xs text-slate-400 mt-1">
+                  PDF, PNG, JPG — max 20 MB
+                </p>
+              </div>
+            </button>
+          ) : (
+            <div className="w-full border-2 border-dashed border-slate-200 rounded-xl p-8 flex flex-col items-center justify-center gap-3 text-slate-500">
+              <Loader2 className="h-8 w-8 animate-spin text-slate-400" />
+              <p className="text-sm font-medium">Uploading file...</p>
+            </div>
+          )}
+
+          {/* Title input */}
+          {(isUpdating || displayPreviewUrl) && (
+            <div className="space-y-2">
+              <Label
+                htmlFor="plan-title"
+                className="text-sm font-medium text-slate-700"
+              >
+                Title
+              </Label>
+              <Input
+                id="plan-title"
+                value={title}
+                onChange={(e) => setTitle(e.target.value)}
+                placeholder="Enter plan title"
+                className="border-slate-200"
+                disabled={submitting}
+              />
+            </div>
+          )}
+
+          {error && (
+            <div className="bg-red-50 text-red-600 px-4 py-3 rounded-lg flex items-center gap-2 text-sm border border-red-100">
+              <AlertCircle className="h-4 w-4 shrink-0" />
+              {error}
+            </div>
+          )}
+        </div>
+
+        {(isUpdating || displayPreviewUrl) && (
+          <div className="px-6 pb-6 flex justify-end gap-3 border-t border-slate-100 pt-4">
+            <Button
+              variant="outline"
+              onClick={onClose}
+              disabled={submitting}
+              className="border-slate-200"
+            >
+              Cancel
+            </Button>
+            <Button
+              onClick={handleSubmit}
+              disabled={!canSubmit}
+              className="bg-[var(--navy)] hover:bg-[var(--navy-hover)] text-white"
+            >
+              {submitting ? (
+                <>
+                  <Loader2 className="h-4 w-4 animate-spin mr-2" />
+                  Saving...
+                </>
+              ) : isUpdating ? (
+                "Update Plan"
+              ) : (
+                "Upload Plan"
+              )}
+            </Button>
+          </div>
+        )}
+
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept=".pdf,.png,.jpg,.jpeg"
+          className="hidden"
+          onChange={handleFileChange}
+        />
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/site-plans/SitePlanViewerDialog.tsx
+++ b/src/components/site-plans/SitePlanViewerDialog.tsx
@@ -458,15 +458,16 @@ export function SitePlanViewerDialog({
                 </>
               )}
             </div>
-            <a href={rawUrl} target="_blank" rel="noreferrer">
-              <Button
-                variant="outline"
-                size="sm"
-                className="border-slate-200 text-slate-700"
-              >
+            <Button
+              variant="outline"
+              size="sm"
+              className="border-slate-200 text-slate-700"
+              asChild
+            >
+              <a href={rawUrl} target="_blank" rel="noreferrer">
                 <Download className="h-4 w-4 mr-1.5" /> Download
-              </Button>
-            </a>
+              </a>
+            </Button>
           </div>
         </DialogContent>
       </Dialog>

--- a/src/components/site-plans/SitePlanViewerDialog.tsx
+++ b/src/components/site-plans/SitePlanViewerDialog.tsx
@@ -32,6 +32,7 @@ import {
 import api from "@/lib/api";
 import type { SitePlan } from "@/types";
 import { getApiErrorMessage } from "@/types";
+import { toProxyUrl } from "@/lib/sitePlanUtils";
 import { SitePlanUploadDialog } from "./SitePlanUploadDialog";
 
 interface SitePlanViewerDialogProps {
@@ -42,11 +43,6 @@ interface SitePlanViewerDialogProps {
   projectId: string;
   onUpdated: (plan: SitePlan) => void;
   onDeleted: (planId: string) => void;
-}
-
-function toProxyUrl(backendUrl: string): string {
-  const path = backendUrl.replace(/^\/api/, "");
-  return `/api/proxy?path=${encodeURIComponent(path)}`;
 }
 
 const MIN_SCALE = 0.05;
@@ -410,9 +406,18 @@ export function SitePlanViewerDialog({
 
           {/* Clickable image — click opens the lightbox */}
           <div
+            role="button"
+            tabIndex={0}
+            aria-label={`View ${plan.title} in full screen`}
             className="relative group cursor-zoom-in overflow-hidden bg-slate-900"
             style={{ height: "55vh" }}
             onClick={() => setLightboxOpen(true)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" || e.key === " ") {
+                e.preventDefault();
+                setLightboxOpen(true);
+              }
+            }}
           >
             {/* eslint-disable-next-line @next/next/no-img-element */}
             <img

--- a/src/components/site-plans/SitePlanViewerDialog.tsx
+++ b/src/components/site-plans/SitePlanViewerDialog.tsx
@@ -1,0 +1,534 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import * as DialogPrimitive from "@radix-ui/react-dialog";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { Button } from "@/components/ui/button";
+import {
+  Download,
+  Edit,
+  Loader2,
+  Maximize2,
+  Minus,
+  Plus,
+  Trash2,
+  X,
+} from "lucide-react";
+import api from "@/lib/api";
+import type { SitePlan } from "@/types";
+import { getApiErrorMessage } from "@/types";
+import { SitePlanUploadDialog } from "./SitePlanUploadDialog";
+
+interface SitePlanViewerDialogProps {
+  plan: SitePlan | null;
+  isOpen: boolean;
+  onClose: () => void;
+  canEdit: boolean;
+  projectId: string;
+  onUpdated: (plan: SitePlan) => void;
+  onDeleted: (planId: string) => void;
+}
+
+function toProxyUrl(backendUrl: string): string {
+  const path = backendUrl.replace(/^\/api/, "");
+  return `/api/proxy?path=${encodeURIComponent(path)}`;
+}
+
+const MIN_SCALE = 0.05;
+const MAX_SCALE = 16;
+const ZOOM_STEP = 0.3;
+
+// ─── Full-screen lightbox ────────────────────────────────────────────────────
+
+interface LightboxProps {
+  src: string;
+  alt: string;
+  title: string;
+  filename: string;
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+function ImageLightbox({
+  src,
+  alt,
+  title,
+  filename,
+  isOpen,
+  onClose,
+}: LightboxProps) {
+  const [scale, setScaleState] = useState(1);
+  const [offset, setOffsetState] = useState({ x: 0, y: 0 });
+  const [isDragging, setIsDragging] = useState(false);
+
+  const scaleRef = useRef(1);
+  const offsetRef = useRef({ x: 0, y: 0 });
+  const containerRef = useRef<HTMLDivElement>(null);
+  const dragStartRef = useRef<{ x: number; y: number } | null>(null);
+  const lastTouchDistRef = useRef<number | null>(null);
+
+  const applyScale = (s: number) => {
+    scaleRef.current = s;
+    setScaleState(s);
+  };
+  const applyOffset = (o: { x: number; y: number }) => {
+    offsetRef.current = o;
+    setOffsetState(o);
+  };
+
+  const resetView = useCallback(() => {
+    applyScale(1);
+    applyOffset({ x: 0, y: 0 });
+  }, []);
+
+  // Reset view when opened
+  useEffect(() => {
+    if (isOpen) resetView();
+  }, [isOpen, resetView]);
+
+  // Non-passive wheel zoom (cursor-centred)
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el || !isOpen) return;
+
+    const onWheel = (e: WheelEvent) => {
+      e.preventDefault();
+      const rect = el.getBoundingClientRect();
+      const cx = e.clientX - rect.left - rect.width / 2;
+      const cy = e.clientY - rect.top - rect.height / 2;
+      const factor = e.deltaY < 0 ? 1.12 : 1 / 1.12;
+      const newScale = Math.min(
+        MAX_SCALE,
+        Math.max(MIN_SCALE, scaleRef.current * factor),
+      );
+      const ratio = newScale / scaleRef.current;
+      applyScale(newScale);
+      applyOffset({
+        x: cx - ratio * (cx - offsetRef.current.x),
+        y: cy - ratio * (cy - offsetRef.current.y),
+      });
+    };
+
+    el.addEventListener("wheel", onWheel, { passive: false });
+    return () => el.removeEventListener("wheel", onWheel);
+  }, [isOpen]);
+
+  // Keyboard shortcuts for zoom (+/-, 0). Escape is handled by Radix.
+  useEffect(() => {
+    if (!isOpen) return;
+    const onKey = (e: KeyboardEvent) => {
+      const tag = (e.target as HTMLElement).tagName;
+      if (tag === "INPUT" || tag === "TEXTAREA") return;
+      if (e.key === "=" || e.key === "+")
+        applyScale(Math.min(MAX_SCALE, scaleRef.current + ZOOM_STEP));
+      else if (e.key === "-")
+        applyScale(Math.max(MIN_SCALE, scaleRef.current - ZOOM_STEP));
+      else if (e.key === "0") resetView();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [isOpen, resetView]);
+
+  // Mouse drag
+  const handleMouseDown = (e: React.MouseEvent) => {
+    if (e.button !== 0) return;
+    e.preventDefault();
+    setIsDragging(true);
+    dragStartRef.current = {
+      x: e.clientX - offsetRef.current.x,
+      y: e.clientY - offsetRef.current.y,
+    };
+  };
+  const handleMouseMove = (e: React.MouseEvent) => {
+    if (!isDragging || !dragStartRef.current) return;
+    applyOffset({
+      x: e.clientX - dragStartRef.current.x,
+      y: e.clientY - dragStartRef.current.y,
+    });
+  };
+  const stopDrag = () => {
+    setIsDragging(false);
+    dragStartRef.current = null;
+  };
+
+  // Touch: single finger = pan, two fingers = pinch zoom
+  const handleTouchStart = (e: React.TouchEvent) => {
+    if (e.touches.length === 1) {
+      setIsDragging(true);
+      dragStartRef.current = {
+        x: e.touches[0].clientX - offsetRef.current.x,
+        y: e.touches[0].clientY - offsetRef.current.y,
+      };
+    } else if (e.touches.length === 2) {
+      setIsDragging(false);
+      dragStartRef.current = null;
+      const dx = e.touches[0].clientX - e.touches[1].clientX;
+      const dy = e.touches[0].clientY - e.touches[1].clientY;
+      lastTouchDistRef.current = Math.sqrt(dx * dx + dy * dy);
+    }
+  };
+  const handleTouchMove = (e: React.TouchEvent) => {
+    if (e.touches.length === 1 && isDragging && dragStartRef.current) {
+      applyOffset({
+        x: e.touches[0].clientX - dragStartRef.current.x,
+        y: e.touches[0].clientY - dragStartRef.current.y,
+      });
+    } else if (
+      e.touches.length === 2 &&
+      lastTouchDistRef.current !== null
+    ) {
+      const dx = e.touches[0].clientX - e.touches[1].clientX;
+      const dy = e.touches[0].clientY - e.touches[1].clientY;
+      const newDist = Math.sqrt(dx * dx + dy * dy);
+      applyScale(
+        Math.min(
+          MAX_SCALE,
+          Math.max(
+            MIN_SCALE,
+            scaleRef.current * (newDist / lastTouchDistRef.current),
+          ),
+        ),
+      );
+      lastTouchDistRef.current = newDist;
+    }
+  };
+  const handleTouchEnd = () => {
+    setIsDragging(false);
+    dragStartRef.current = null;
+    lastTouchDistRef.current = null;
+  };
+
+  // Use Radix Dialog primitives so Radix's DismissableLayer stack tracks this as
+  // a nested layer — the outer viewer dialog won't close when the lightbox closes.
+  return (
+    <DialogPrimitive.Root open={isOpen} onOpenChange={(open) => !open && onClose()}>
+      <DialogPrimitive.Portal>
+        <DialogPrimitive.Overlay
+          className="fixed inset-0 z-[9999] data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 duration-200"
+          style={{ background: "rgba(0,0,0,0.93)" }}
+        />
+        <DialogPrimitive.Content
+          className="fixed inset-0 z-[9999] flex flex-col outline-none data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 duration-200"
+          // Prevent Radix from auto-closing this content on outside pointer/focus events
+          onPointerDownOutside={(e) => e.preventDefault()}
+          onInteractOutside={(e) => e.preventDefault()}
+          aria-describedby={undefined}
+        >
+          <DialogPrimitive.Title className="sr-only">{title}</DialogPrimitive.Title>
+
+          {/* ── Top bar ── */}
+          <div className="flex-shrink-0 flex items-center justify-between px-5 py-3 bg-gradient-to-b from-black/60 to-transparent pointer-events-none">
+            <div className="min-w-0 pointer-events-auto">
+              <p className="text-white font-semibold text-sm truncate leading-tight">
+                {title}
+              </p>
+              <p className="text-white/40 text-xs truncate mt-0.5">{filename}</p>
+            </div>
+            <DialogPrimitive.Close asChild>
+              <button
+                className="pointer-events-auto flex-shrink-0 ml-4 w-9 h-9 flex items-center justify-center rounded-full text-white/60 hover:text-white hover:bg-white/15 transition-colors"
+                aria-label="Close lightbox"
+              >
+                <X className="h-5 w-5" />
+              </button>
+            </DialogPrimitive.Close>
+          </div>
+
+          {/* ── Image canvas ── */}
+          <div
+            ref={containerRef}
+            className="flex-1 overflow-hidden select-none"
+            style={{
+              cursor: isDragging ? "grabbing" : "grab",
+              touchAction: "none",
+            }}
+            onMouseDown={handleMouseDown}
+            onMouseMove={handleMouseMove}
+            onMouseUp={stopDrag}
+            onMouseLeave={stopDrag}
+            onTouchStart={handleTouchStart}
+            onTouchMove={handleTouchMove}
+            onTouchEnd={handleTouchEnd}
+            onDoubleClick={resetView}
+          >
+            <div
+              className="w-full h-full flex items-center justify-center"
+              style={{
+                transform: `translate(${offset.x}px, ${offset.y}px) scale(${scale})`,
+                transformOrigin: "center center",
+                willChange: "transform",
+                transition: isDragging ? "none" : "transform 0.05s ease-out",
+              }}
+            >
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img
+                src={src}
+                alt={alt}
+                draggable={false}
+                className="max-w-full max-h-full object-contain pointer-events-none select-none"
+                style={{ maxHeight: "calc(100vh - 130px)" }}
+              />
+            </div>
+          </div>
+
+          {/* ── Bottom toolbar ── */}
+          <div
+            className="flex-shrink-0 py-5 flex justify-center gap-3"
+            onMouseDown={(e) => e.stopPropagation()}
+          >
+            <div className="flex items-center gap-0.5 bg-white/10 backdrop-blur-md px-2 py-1.5 rounded-full border border-white/10 shadow-2xl">
+              <button
+                className="w-8 h-8 flex items-center justify-center text-white/60 hover:text-white hover:bg-white/15 rounded-full transition-colors"
+                onClick={() =>
+                  applyScale(Math.max(MIN_SCALE, scaleRef.current - ZOOM_STEP))
+                }
+                title="Zoom out (−)"
+              >
+                <Minus className="h-4 w-4" />
+              </button>
+
+              <button
+                className="min-w-[3.5rem] text-white/85 text-xs font-mono text-center hover:bg-white/10 rounded-full px-2 py-1 transition-colors"
+                onClick={resetView}
+                title="Reset zoom (0)"
+              >
+                {Math.round(scale * 100)}%
+              </button>
+
+              <button
+                className="w-8 h-8 flex items-center justify-center text-white/60 hover:text-white hover:bg-white/15 rounded-full transition-colors"
+                onClick={() =>
+                  applyScale(Math.min(MAX_SCALE, scaleRef.current + ZOOM_STEP))
+                }
+                title="Zoom in (+)"
+              >
+                <Plus className="h-4 w-4" />
+              </button>
+
+              <div className="w-px h-4 bg-white/20 mx-1" />
+
+              {[1, 2, 4].map((z) => (
+                <button
+                  key={z}
+                  className={`text-[11px] font-medium px-2 py-1 rounded-full transition-colors ${
+                    Math.round(scale * 100) === z * 100
+                      ? "bg-white/25 text-white"
+                      : "text-white/50 hover:text-white hover:bg-white/15"
+                  }`}
+                  onClick={() => {
+                    applyScale(z);
+                    applyOffset({ x: 0, y: 0 });
+                  }}
+                  title={`${z * 100}%`}
+                >
+                  {z}×
+                </button>
+              ))}
+
+              <div className="w-px h-4 bg-white/20 mx-1" />
+
+              <button
+                className="w-8 h-8 flex items-center justify-center text-white/60 hover:text-white hover:bg-white/15 rounded-full transition-colors"
+                onClick={resetView}
+                title="Fit to view (0)"
+              >
+                <Maximize2 className="h-4 w-4" />
+              </button>
+            </div>
+          </div>
+        </DialogPrimitive.Content>
+      </DialogPrimitive.Portal>
+    </DialogPrimitive.Root>
+  );
+}
+
+// ─── Viewer dialog ────────────────────────────────────────────────────────────
+
+export function SitePlanViewerDialog({
+  plan,
+  isOpen,
+  onClose,
+  canEdit,
+  projectId,
+  onUpdated,
+  onDeleted,
+}: SitePlanViewerDialogProps) {
+  const [isDeleteConfirmOpen, setIsDeleteConfirmOpen] = useState(false);
+  const [isUpdateOpen, setIsUpdateOpen] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
+  const [lightboxOpen, setLightboxOpen] = useState(false);
+
+  if (!plan) return null;
+
+  const imageUrl = toProxyUrl(plan.file.image_url);
+  const rawUrl = toProxyUrl(plan.file.raw_url);
+
+  const handleDelete = async () => {
+    setDeleting(true);
+    setDeleteError(null);
+    try {
+      await api.delete(`/site-plans/${plan.id}`);
+      setIsDeleteConfirmOpen(false);
+      onDeleted(plan.id);
+      onClose();
+    } catch (err) {
+      setDeleteError(getApiErrorMessage(err, "Failed to delete site plan"));
+    } finally {
+      setDeleting(false);
+    }
+  };
+
+  return (
+    <>
+      <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
+        <DialogContent className="w-[calc(100vw-1rem)] max-w-2xl bg-white p-0 gap-0 border-slate-200 shadow-2xl overflow-hidden">
+          {/* Header */}
+          <DialogHeader className="px-6 pt-5 pb-4 border-b border-slate-100 pr-14">
+            <DialogTitle className="text-base font-semibold text-slate-900 truncate">
+              {plan.title}
+            </DialogTitle>
+            <p className="text-xs text-slate-400 mt-0.5 truncate">
+              {plan.file.original_filename}
+            </p>
+          </DialogHeader>
+
+          {/* Clickable image — click opens the lightbox */}
+          <div
+            className="relative group cursor-zoom-in overflow-hidden bg-slate-900"
+            style={{ height: "55vh" }}
+            onClick={() => setLightboxOpen(true)}
+          >
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              src={imageUrl}
+              alt={plan.title}
+              draggable={false}
+              className="w-full h-full object-contain pointer-events-none select-none"
+            />
+            {/* Expand hint on hover */}
+            <div className="absolute inset-0 bg-black/0 group-hover:bg-black/30 flex items-center justify-center transition-all duration-200">
+              <div className="opacity-0 group-hover:opacity-100 scale-90 group-hover:scale-100 transition-all duration-200 bg-black/55 backdrop-blur-sm rounded-full p-3.5">
+                <Maximize2 className="h-6 w-6 text-white" />
+              </div>
+            </div>
+          </div>
+
+          {/* Footer */}
+          <div className="px-6 py-4 flex flex-wrap items-center justify-between gap-2 border-t border-slate-100">
+            <div className="flex gap-2">
+              {canEdit && (
+                <>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className="border-slate-200 text-slate-700"
+                    onClick={() => setIsUpdateOpen(true)}
+                  >
+                    <Edit className="h-4 w-4 mr-1.5" /> Update
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="text-red-600 hover:bg-red-50 hover:text-red-700"
+                    onClick={() => setIsDeleteConfirmOpen(true)}
+                  >
+                    <Trash2 className="h-4 w-4 mr-1.5" /> Delete
+                  </Button>
+                </>
+              )}
+            </div>
+            <a href={rawUrl} target="_blank" rel="noreferrer">
+              <Button
+                variant="outline"
+                size="sm"
+                className="border-slate-200 text-slate-700"
+              >
+                <Download className="h-4 w-4 mr-1.5" /> Download
+              </Button>
+            </a>
+          </div>
+        </DialogContent>
+      </Dialog>
+
+      {/* Full-screen lightbox — Radix Dialog so layer stack is managed correctly */}
+      <ImageLightbox
+        src={imageUrl}
+        alt={plan.title}
+        title={plan.title}
+        filename={plan.file.original_filename}
+        isOpen={lightboxOpen}
+        onClose={() => setLightboxOpen(false)}
+      />
+
+      {/* Delete confirmation */}
+      <AlertDialog
+        open={isDeleteConfirmOpen}
+        onOpenChange={(open) => {
+          if (!open) {
+            setIsDeleteConfirmOpen(false);
+            setDeleteError(null);
+          }
+        }}
+      >
+        <AlertDialogContent className="w-[calc(100vw-1rem)] bg-white">
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete Site Plan?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This will permanently delete &quot;{plan.title}&quot; and its
+              file. This cannot be undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          {deleteError && (
+            <p className="text-red-600 text-sm px-1">{deleteError}</p>
+          )}
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={deleting}>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              disabled={deleting}
+              className="bg-red-600 hover:bg-red-700 text-white"
+              onClick={(e) => {
+                e.preventDefault();
+                void handleDelete();
+              }}
+            >
+              {deleting ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : (
+                "Delete"
+              )}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      {/* Update dialog */}
+      <SitePlanUploadDialog
+        isOpen={isUpdateOpen}
+        onClose={() => setIsUpdateOpen(false)}
+        projectId={projectId}
+        existingPlan={plan}
+        onSuccess={(updatedPlan) => {
+          setIsUpdateOpen(false);
+          onUpdated(updatedPlan);
+          onClose();
+        }}
+      />
+    </>
+  );
+}

--- a/src/components/site-plans/SitePlansSection.tsx
+++ b/src/components/site-plans/SitePlansSection.tsx
@@ -7,17 +7,13 @@ import { ImageIcon, Plus } from "lucide-react";
 import useSWR from "swr";
 import { swrFetcher, SWR_CONFIG } from "@/lib/swr";
 import type { SitePlan } from "@/types";
+import { toProxyUrl } from "@/lib/sitePlanUtils";
 import { SitePlanUploadDialog } from "./SitePlanUploadDialog";
 import { SitePlanViewerDialog } from "./SitePlanViewerDialog";
 
 interface SitePlansSectionProps {
   projectId: string;
   canEdit: boolean;
-}
-
-function toProxyUrl(backendUrl: string): string {
-  const path = backendUrl.replace(/^\/api/, "");
-  return `/api/proxy?path=${encodeURIComponent(path)}`;
 }
 
 export function SitePlansSection({ projectId, canEdit }: SitePlansSectionProps) {
@@ -27,6 +23,7 @@ export function SitePlansSection({ projectId, canEdit }: SitePlansSectionProps) 
   const {
     data: plansRaw,
     isLoading,
+    error,
     mutate,
   } = useSWR(
     projectId ? `/site-plans/?project_id=${projectId}` : null,
@@ -60,7 +57,13 @@ export function SitePlansSection({ projectId, canEdit }: SitePlansSectionProps) 
       </div>
 
       <div className="bg-white rounded-2xl shadow-sm border border-slate-100 overflow-hidden min-h-[400px]">
-        {isLoading ? (
+        {error && !isLoading ? (
+          <div className="flex flex-col items-center justify-center py-12 px-6 text-center h-full min-h-[400px]">
+            <div className="bg-amber-50 border border-amber-200 text-amber-800 px-4 py-3 rounded-lg text-sm w-full max-w-xs">
+              Failed to load site plans. Please try again.
+            </div>
+          </div>
+        ) : isLoading ? (
           <div className="p-3">
             <div className="grid grid-cols-2 gap-3">
               {[1, 2].map((i) => (

--- a/src/components/site-plans/SitePlansSection.tsx
+++ b/src/components/site-plans/SitePlansSection.tsx
@@ -1,0 +1,152 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import { ImageIcon, Plus } from "lucide-react";
+import useSWR from "swr";
+import { swrFetcher, SWR_CONFIG } from "@/lib/swr";
+import type { SitePlan } from "@/types";
+import { SitePlanUploadDialog } from "./SitePlanUploadDialog";
+import { SitePlanViewerDialog } from "./SitePlanViewerDialog";
+
+interface SitePlansSectionProps {
+  projectId: string;
+  canEdit: boolean;
+}
+
+function toProxyUrl(backendUrl: string): string {
+  const path = backendUrl.replace(/^\/api/, "");
+  return `/api/proxy?path=${encodeURIComponent(path)}`;
+}
+
+export function SitePlansSection({ projectId, canEdit }: SitePlansSectionProps) {
+  const [isUploadOpen, setIsUploadOpen] = useState(false);
+  const [viewingPlan, setViewingPlan] = useState<SitePlan | null>(null);
+
+  const {
+    data: plansRaw,
+    isLoading,
+    mutate,
+  } = useSWR(
+    projectId ? `/site-plans/?project_id=${projectId}` : null,
+    swrFetcher,
+    SWR_CONFIG,
+  );
+
+  const plans = useMemo<SitePlan[]>(() => {
+    if (!plansRaw) return [];
+    if (Array.isArray(plansRaw)) return plansRaw;
+    if (Array.isArray((plansRaw as { site_plans?: SitePlan[] }).site_plans))
+      return (plansRaw as { site_plans: SitePlan[] }).site_plans;
+    if (Array.isArray((plansRaw as { items?: SitePlan[] }).items))
+      return (plansRaw as { items: SitePlan[] }).items;
+    return [];
+  }, [plansRaw]);
+
+  return (
+    <>
+      <div className="flex justify-between items-center mb-2">
+        <h2 className="text-xl font-bold text-slate-900">Site Plans</h2>
+        {canEdit && (
+          <Button
+            size="sm"
+            onClick={() => setIsUploadOpen(true)}
+            className="bg-[var(--navy)] hover:bg-[var(--navy-hover)] text-white"
+          >
+            <Plus className="h-4 w-4 mr-1" /> Upload Plan
+          </Button>
+        )}
+      </div>
+
+      <div className="bg-white rounded-2xl shadow-sm border border-slate-100 overflow-hidden min-h-[400px]">
+        {isLoading ? (
+          <div className="p-3">
+            <div className="grid grid-cols-2 gap-3">
+              {[1, 2].map((i) => (
+                <div key={i} className="rounded-xl overflow-hidden">
+                  <Skeleton className="aspect-video w-full" />
+                  <div className="p-3 space-y-2">
+                    <Skeleton className="h-4 w-3/4 rounded" />
+                    <Skeleton className="h-3 w-1/2 rounded" />
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        ) : plans.length === 0 ? (
+          <div className="flex flex-col items-center justify-center py-12 px-6 text-center h-full min-h-[400px]">
+            <div className="w-12 h-12 rounded-full bg-slate-50 flex items-center justify-center mb-3">
+              <ImageIcon className="h-6 w-6 text-slate-400" />
+            </div>
+            <p className="text-sm font-medium text-slate-600">
+              No site plans yet
+            </p>
+            {canEdit && (
+              <p className="text-xs text-slate-400 mt-1">
+                Upload the first plan to get started
+              </p>
+            )}
+          </div>
+        ) : (
+          <div className="overflow-y-auto max-h-[600px] p-3 custom-scrollbar">
+            <div className={`grid gap-3 ${plans.length === 1 ? "grid-cols-1" : "grid-cols-1 sm:grid-cols-2"}`}>
+              {plans.map((plan) => (
+                <button
+                  key={plan.id}
+                  onClick={() => setViewingPlan(plan)}
+                  className="group rounded-xl border border-slate-100 hover:border-slate-200 hover:shadow-md transition-all overflow-hidden bg-white cursor-pointer text-left"
+                >
+                  {/* Preview */}
+                  <div className="w-full aspect-video bg-slate-100 overflow-hidden">
+                    {/* eslint-disable-next-line @next/next/no-img-element */}
+                    <img
+                      src={toProxyUrl(plan.file.preview_url)}
+                      alt={plan.title}
+                      className="w-full h-full object-cover group-hover:scale-105 transition-transform duration-300"
+                    />
+                  </div>
+                  {/* Info */}
+                  <div className="px-3 py-2.5">
+                    <p className="font-semibold text-sm text-slate-900 truncate">
+                      {plan.title}
+                    </p>
+                    <p className="text-xs text-slate-400 truncate mt-0.5">
+                      {plan.file.original_filename}
+                    </p>
+                  </div>
+                </button>
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+
+      <SitePlanUploadDialog
+        isOpen={isUploadOpen}
+        onClose={() => setIsUploadOpen(false)}
+        projectId={projectId}
+        onSuccess={() => {
+          setIsUploadOpen(false);
+          void mutate();
+        }}
+      />
+
+      <SitePlanViewerDialog
+        plan={viewingPlan}
+        isOpen={!!viewingPlan}
+        onClose={() => setViewingPlan(null)}
+        canEdit={canEdit}
+        projectId={projectId}
+        onUpdated={() => {
+          setViewingPlan(null);
+          void mutate();
+        }}
+        onDeleted={() => {
+          setViewingPlan(null);
+          void mutate();
+        }}
+      />
+    </>
+  );
+}

--- a/src/lib/sitePlanUtils.ts
+++ b/src/lib/sitePlanUtils.ts
@@ -1,0 +1,22 @@
+/** Converts a backend-relative URL (e.g. /api/files/uuid/preview) into a
+ *  browser-accessible proxy URL (/api/proxy?path=/files/uuid/preview). */
+export function toProxyUrl(backendUrl: string): string {
+  const path = backendUrl.replace(/^\/api/, "");
+  return `/api/proxy?path=${encodeURIComponent(path)}`;
+}
+
+export const SITE_PLAN_ALLOWED_TYPES = [
+  "application/pdf",
+  "image/png",
+  "image/jpeg",
+] as const;
+
+export const SITE_PLAN_MAX_BYTES = 20 * 1024 * 1024; // 20 MB
+
+/** Returns a user-facing error string if the file is invalid, null if OK. */
+export function validateSitePlanFile(file: File): string | null {
+  if (file.size > SITE_PLAN_MAX_BYTES) return "File must be under 20 MB";
+  if (!SITE_PLAN_ALLOWED_TYPES.includes(file.type as (typeof SITE_PLAN_ALLOWED_TYPES)[number]))
+    return "Only PDF, PNG, or JPG files are allowed";
+  return null;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -220,6 +220,43 @@ export interface AuditTrailResponse {
   history: AuditEntry[];
 }
 
+// ===== SITE PLANS =====
+
+export interface SitePlanFile {
+  id: string;
+  original_filename: string;
+  content_type: string;
+  file_size: number;
+  preview_url: string;
+  image_url: string;
+  raw_url: string;
+}
+
+export interface SitePlan {
+  id: string;
+  title: string;
+  project_id: string;
+  created_at: string;
+  updated_at: string;
+  file: SitePlanFile;
+  created_by: {
+    id: string;
+    email: string;
+    first_name: string;
+    last_name: string;
+    role: string;
+  };
+}
+
+export interface FileUploadResponse {
+  file_id: string;
+  suggested_title: string;
+  original_filename: string;
+  content_type: string;
+  file_size: number;
+  preview_url: string;
+}
+
 // ===== ERROR HANDLING =====
 
 function isRecord(value: unknown): value is Record<string, unknown> {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dashboard right column now shows a per-project Site Plans gallery with upload, viewer, edit, and delete workflows. Full-screen lightbox supports pan/zoom and download. Upload dialog enforces PDF/PNG/JPG and 20MB limits. Edit permission shown for admin/manager roles.
  * Removed the prior calendar content from the right column when a project is selected.

* **Bug Fixes / Improvements**
  * Improved proxy and multipart/binary handling for uploads, previews, and token-refresh responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->