### PR TITLE
Propagate ETag header and handle 204/304 responses in proxy API

### DIFF
--- a/src/app/api/proxy/route.ts
+++ b/src/app/api/proxy/route.ts
@@ -49,6 +49,8 @@ async function buildNextResponse(
     };
     const cacheControl = response.headers.get("cache-control");
     if (cacheControl) responseHeaders["Cache-Control"] = cacheControl;
+    const etag = response.headers.get("etag");
+    if (etag) responseHeaders["ETag"] = etag;
     const contentDisposition = response.headers.get("content-disposition");
     if (contentDisposition)
       responseHeaders["Content-Disposition"] = contentDisposition;
@@ -56,6 +58,8 @@ async function buildNextResponse(
       status: response.status,
       headers: responseHeaders,
     });
+  } else if (response.status === 204 || response.status === 304) {
+    res = new NextResponse(null, { status: response.status });
   } else {
     const data = await response.json().catch(() => null);
     res = NextResponse.json(data, { status: response.status });

--- a/src/app/api/proxy/route.ts
+++ b/src/app/api/proxy/route.ts
@@ -42,7 +42,14 @@ async function buildNextResponse(
 
   let res: NextResponse;
 
-  if (isBinary) {
+  if (response.status === 204 || response.status === 304) {
+    const noBodyHeaders: Record<string, string> = {};
+    const cacheControl = response.headers.get("cache-control");
+    if (cacheControl) noBodyHeaders["Cache-Control"] = cacheControl;
+    const etag = response.headers.get("etag");
+    if (etag) noBodyHeaders["ETag"] = etag;
+    res = new NextResponse(null, { status: response.status, headers: noBodyHeaders });
+  } else if (isBinary) {
     const buffer = await response.arrayBuffer();
     const responseHeaders: Record<string, string> = {
       "Content-Type": respContentType,
@@ -58,8 +65,6 @@ async function buildNextResponse(
       status: response.status,
       headers: responseHeaders,
     });
-  } else if (response.status === 204 || response.status === 304) {
-    res = new NextResponse(null, { status: response.status });
   } else {
     const data = await response.json().catch(() => null);
     res = NextResponse.json(data, { status: response.status });

--- a/src/components/site-plans/SitePlansSection.tsx
+++ b/src/components/site-plans/SitePlansSection.tsx
@@ -106,6 +106,7 @@ export function SitePlansSection({ projectId, canEdit }: SitePlansSectionProps) 
                     <img
                       src={toProxyUrl(plan.file.preview_url)}
                       alt={plan.title}
+                      loading="lazy"
                       className="w-full h-full object-cover group-hover:scale-105 transition-transform duration-300"
                     />
                   </div>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed handling of empty HTTP responses (204/304) to avoid parsing errors and return only relevant headers.
  * Ensured consistent propagation of ETag and Content-Disposition for streamed/binary responses.

* **Performance**
  * Added lazy loading to site plan images for improved page load performance.
  * Improved cache header management for more reliable response handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->