### PR TITLE
Add error handling and retry to lookahead dashboard

### DIFF
--- a/src/components/lookahead/EmptyForecastState.tsx
+++ b/src/components/lookahead/EmptyForecastState.tsx
@@ -1,17 +1,74 @@
-import { BarChart3 } from "lucide-react";
+import { AlertTriangle, BarChart3 } from "lucide-react";
+import { Button } from "@/components/ui/button";
 
-export function EmptyForecastState({ reason }: { reason: "no-project" | "no-data" }) {
+type EmptyForecastReason = "no-project" | "no-data" | "load-error";
+
+interface EmptyForecastStateProps {
+  reason: EmptyForecastReason;
+  title?: string;
+  message?: string;
+  actionLabel?: string;
+  onAction?: () => void;
+}
+
+const STATE_COPY: Record<
+  EmptyForecastReason,
+  { title: string; message: string; icon: typeof BarChart3; iconClassName: string }
+> = {
+  "no-project": {
+    title: "Choose a project to begin",
+    message: "Select a project above to view its resource demand forecast.",
+    icon: BarChart3,
+    iconClassName: "text-slate-300",
+  },
+  "no-data": {
+    title: "No forecast data",
+    message:
+      "Upload your programme file (CSV, Excel, or PDF) to generate the forecast. The AI will read the schedule and predict how many hours of each resource type you'll need each week.",
+    icon: BarChart3,
+    iconClassName: "text-slate-300",
+  },
+  "load-error": {
+    title: "Forecast temporarily unavailable",
+    message:
+      "We couldn't load the latest planning forecast right now. Try again in a moment.",
+    icon: AlertTriangle,
+    iconClassName: "text-amber-500",
+  },
+};
+
+export function EmptyForecastState({
+  reason,
+  title,
+  message,
+  actionLabel,
+  onAction,
+}: EmptyForecastStateProps) {
+  const state = STATE_COPY[reason];
+  const Icon = state.icon;
+
   return (
-    <div className="flex flex-col items-center justify-center py-14 px-6 text-center border-2 border-dashed border-slate-100 rounded-xl">
-      <div className="w-16 h-16 rounded-full bg-slate-50 flex items-center justify-center mb-4">
-        <BarChart3 size={28} className="text-slate-300" />
+    <div className="flex flex-col items-center justify-center rounded-xl border-2 border-dashed border-slate-100 px-6 py-14 text-center">
+      <div className="mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-slate-50">
+        <Icon size={28} className={state.iconClassName} />
       </div>
-      <h3 className="text-base font-bold text-slate-900 mb-1">No forecast data</h3>
-      <p className="text-sm text-slate-500 max-w-sm">
-        {reason === "no-project"
-          ? "Select a project above to view its resource demand forecast."
-          : "Upload your programme file (CSV, Excel, or PDF) to generate the forecast. The AI will read the schedule and predict how many hours of each resource type you'll need each week."}
+      <h3 className="mb-1 text-base font-bold text-slate-900">
+        {title ?? state.title}
+      </h3>
+      <p className="max-w-md text-sm text-slate-500">
+        {message ?? state.message}
       </p>
+      {onAction && actionLabel && (
+        <Button
+          type="button"
+          variant={reason === "load-error" ? "default" : "outline"}
+          size="sm"
+          onClick={onAction}
+          className="mt-5"
+        >
+          {actionLabel}
+        </Button>
+      )}
     </div>
   );
 }

--- a/src/components/lookahead/LookaheadDashboard.tsx
+++ b/src/components/lookahead/LookaheadDashboard.tsx
@@ -81,6 +81,7 @@ type ActivityDialogMode = "context" | "booking";
 
 const WINDOW_WEEKS: Record<WindowSize, number> = { "2W": 2, "4W": 4, "6W": 6 };
 const POLL_MAX_ATTEMPTS = 60;
+const DEFAULT_ERROR_MSG = "Something went wrong";
 
 function isWindowSize(value: unknown): value is WindowSize {
   return typeof value === "string" && value in WINDOW_WEEKS;
@@ -159,7 +160,9 @@ function getForecastLoadMessage(
     ? `Your latest upload from ${latestUploadDate} is still saved, but `
     : "";
   const fallback = `${uploadPrefix}the planning forecast could not be loaded right now.`;
-  const rawMessage = getApiErrorMessage(error, fallback).trim();
+  const rawMessage = getApiErrorMessage(error, DEFAULT_ERROR_MSG).trim();
+  const resolvedMessage =
+    rawMessage === DEFAULT_ERROR_MSG ? fallback : rawMessage;
 
   if (
     /offset-naive|offset-aware/i.test(rawMessage) ||
@@ -185,20 +188,23 @@ function getForecastLoadMessage(
     title: latestUploadDate
       ? "Couldn't refresh the forecast"
       : "Couldn't load the forecast",
-    message: rawMessage === fallback ? fallback : `${fallback} ${rawMessage}`,
+    message:
+      resolvedMessage === fallback || resolvedMessage.startsWith(fallback)
+        ? fallback
+        : `${fallback} ${resolvedMessage}`,
   };
 }
 
 function getDiagnosticsLoadMessage(error: unknown): string {
   const fallback =
     "Planning diagnostics could not be refreshed right now. You can still use the heatmap, but alert badges may be stale until the next retry.";
-  const rawMessage = getApiErrorMessage(error, fallback).trim();
+  const rawMessage = getApiErrorMessage(error, DEFAULT_ERROR_MSG).trim();
 
   if (
     /offset-naive|offset-aware/i.test(rawMessage) ||
     (isAxiosError(error) && (error.response?.status ?? 0) >= 500) ||
     /status code 5\d\d/i.test(rawMessage) ||
-    rawMessage === "Something went wrong"
+    rawMessage === DEFAULT_ERROR_MSG
   ) {
     return fallback;
   }

--- a/src/components/lookahead/LookaheadDashboard.tsx
+++ b/src/components/lookahead/LookaheadDashboard.tsx
@@ -645,6 +645,7 @@ export default function LookaheadDashboard() {
     () => (alertsError ? getDiagnosticsLoadMessage(alertsError) : null),
     [alertsError],
   );
+  const hasBlockingSnapshotError = Boolean(snapshotError && !heatmap);
 
   const activeAlerts = useMemo((): PlanningAlert[] => {
     const flags = (alerts?.alerts as LookaheadAnomalyFlags | undefined) ?? {};
@@ -697,7 +698,7 @@ export default function LookaheadDashboard() {
       });
     }
 
-    if (alertsError && !snapshotError && diagnosticsLoadMessage) {
+    if (alertsError && !hasBlockingSnapshotError && diagnosticsLoadMessage) {
       nextAlerts.push({
         key: "diagnostics_unavailable",
         label: "Diagnostics temporarily unavailable",
@@ -716,9 +717,9 @@ export default function LookaheadDashboard() {
     alertsError,
     diagnosticsLoadMessage,
     dismissedAlerts,
+    hasBlockingSnapshotError,
     mutateAlerts,
     persistentUploadMessage,
-    snapshotError,
   ]);
   const firstSuggestedBookingDate = bookingContext?.suggested_bulk_dates[0] ?? null;
 
@@ -767,7 +768,7 @@ export default function LookaheadDashboard() {
   const focusHeadline =
     !projectId
       ? "Start by selecting a project"
-      : snapshotError
+      : hasBlockingSnapshotError
         ? forecastLoadState?.title ?? "Forecast temporarily unavailable"
       : stats.totalGapHours > 0
         ? `${stats.totalGapHours}h still unbooked`
@@ -777,7 +778,7 @@ export default function LookaheadDashboard() {
   const focusDescription =
     !projectId
       ? "Choose a project and upload a programme to turn this into a planning workspace."
-      : snapshotError
+      : hasBlockingSnapshotError
         ? forecastLoadState?.message ??
           "The latest planning forecast could not be loaded right now."
       : stats.totalGapHours > 0
@@ -1159,7 +1160,7 @@ export default function LookaheadDashboard() {
                 </div>
               ) : !projectId ? (
                 <EmptyForecastState reason="no-project" />
-              ) : snapshotError ? (
+              ) : hasBlockingSnapshotError ? (
                 <EmptyForecastState
                   reason="load-error"
                   title={forecastLoadState?.title}

--- a/src/components/lookahead/LookaheadDashboard.tsx
+++ b/src/components/lookahead/LookaheadDashboard.tsx
@@ -39,7 +39,7 @@ import type {
   LookaheadAnomalyFlags,
   LookaheadRow,
 } from "@/types";
-import { getApiErrorMessage } from "@/types";
+import { getApiErrorMessage, isAxiosError } from "@/types";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { DemandHeatmap } from "./DemandHeatmap";
@@ -151,6 +151,61 @@ function getPersistentUploadAlertMessage(
   return null;
 }
 
+function getForecastLoadMessage(
+  error: unknown,
+  latestUploadDate: string | null,
+): { title: string; message: string } {
+  const uploadPrefix = latestUploadDate
+    ? `Your latest upload from ${latestUploadDate} is still saved, but `
+    : "";
+  const fallback = `${uploadPrefix}the planning forecast could not be loaded right now.`;
+  const rawMessage = getApiErrorMessage(error, fallback).trim();
+
+  if (
+    /offset-naive|offset-aware/i.test(rawMessage) ||
+    (isAxiosError(error) && (error.response?.status ?? 0) >= 500) ||
+    /status code 5\d\d/i.test(rawMessage)
+  ) {
+    return {
+      title: "Forecast temporarily unavailable",
+      message: `${uploadPrefix}the server hit a processing issue while rebuilding the heatmap. Try again in a moment.`,
+    };
+  }
+
+  if (isAxiosError(error) && error.response?.status === 404) {
+    return {
+      title: "Forecast not ready yet",
+      message: latestUploadDate
+        ? `The latest upload from ${latestUploadDate} is saved, but the forecast snapshot is not available yet. Try again shortly.`
+        : "This project does not have a forecast snapshot yet. Upload a programme or try again shortly.",
+    };
+  }
+
+  return {
+    title: latestUploadDate
+      ? "Couldn't refresh the forecast"
+      : "Couldn't load the forecast",
+    message: rawMessage === fallback ? fallback : `${fallback} ${rawMessage}`,
+  };
+}
+
+function getDiagnosticsLoadMessage(error: unknown): string {
+  const fallback =
+    "Planning diagnostics could not be refreshed right now. You can still use the heatmap, but alert badges may be stale until the next retry.";
+  const rawMessage = getApiErrorMessage(error, fallback).trim();
+
+  if (
+    /offset-naive|offset-aware/i.test(rawMessage) ||
+    (isAxiosError(error) && (error.response?.status ?? 0) >= 500) ||
+    /status code 5\d\d/i.test(rawMessage) ||
+    rawMessage === "Something went wrong"
+  ) {
+    return fallback;
+  }
+
+  return rawMessage;
+}
+
 export default function LookaheadDashboard() {
   const { user, isLoading: authLoading } = useAuth();
   const userId = user?.id;
@@ -225,10 +280,18 @@ export default function LookaheadDashboard() {
   );
 
   const enabled = Boolean(projectId);
-  const { snapshot, isLoading: snapshotLoading, mutate: mutateSnapshot } =
-    useLookaheadSnapshot({ projectId, enabled });
-  const { alerts, isLoading: alertsLoading, mutate: mutateAlerts } =
-    useLookaheadAlerts({ projectId, enabled });
+  const {
+    snapshot,
+    isLoading: snapshotLoading,
+    error: snapshotError,
+    mutate: mutateSnapshot,
+  } = useLookaheadSnapshot({ projectId, enabled });
+  const {
+    alerts,
+    isLoading: alertsLoading,
+    error: alertsError,
+    mutate: mutateAlerts,
+  } = useLookaheadAlerts({ projectId, enabled });
   const {
     history,
     isLoading: historyLoading,
@@ -561,6 +624,27 @@ export default function LookaheadDashboard() {
       ),
     [unclassifiedCount, uploadStatus?.completeness_notes],
   );
+  const latestUploadDate = latestVersion?.created_at
+    ? new Date(latestVersion.created_at).toLocaleString("en-AU", {
+        day: "2-digit",
+        month: "short",
+        year: "numeric",
+        hour: "2-digit",
+        minute: "2-digit",
+      })
+    : null;
+  const hydratedLatestUploadDate = hasMounted ? latestUploadDate : null;
+  const forecastLoadState = useMemo(
+    () =>
+      snapshotError
+        ? getForecastLoadMessage(snapshotError, hydratedLatestUploadDate)
+        : null,
+    [hydratedLatestUploadDate, snapshotError],
+  );
+  const diagnosticsLoadMessage = useMemo(
+    () => (alertsError ? getDiagnosticsLoadMessage(alertsError) : null),
+    [alertsError],
+  );
 
   const activeAlerts = useMemo((): PlanningAlert[] => {
     const flags = (alerts?.alerts as LookaheadAnomalyFlags | undefined) ?? {};
@@ -613,18 +697,29 @@ export default function LookaheadDashboard() {
       });
     }
 
-    return nextAlerts.filter((alert) => !dismissedAlerts.has(alert.key));
-  }, [alerts, dismissedAlerts, persistentUploadMessage]);
+    if (alertsError && !snapshotError && diagnosticsLoadMessage) {
+      nextAlerts.push({
+        key: "diagnostics_unavailable",
+        label: "Diagnostics temporarily unavailable",
+        detail: diagnosticsLoadMessage,
+        level: "blue",
+        ctaLabel: "Retry diagnostics",
+        onAction: () => {
+          void mutateAlerts();
+        },
+      });
+    }
 
-  const latestUploadDate = latestVersion?.created_at
-    ? new Date(latestVersion.created_at).toLocaleString("en-AU", {
-        day: "2-digit",
-        month: "short",
-        year: "numeric",
-        hour: "2-digit",
-        minute: "2-digit",
-      })
-    : null;
+    return nextAlerts.filter((alert) => !dismissedAlerts.has(alert.key));
+  }, [
+    alerts,
+    alertsError,
+    diagnosticsLoadMessage,
+    dismissedAlerts,
+    mutateAlerts,
+    persistentUploadMessage,
+    snapshotError,
+  ]);
   const firstSuggestedBookingDate = bookingContext?.suggested_bulk_dates[0] ?? null;
 
   const bookingStartTime = useMemo(() => {
@@ -672,6 +767,8 @@ export default function LookaheadDashboard() {
   const focusHeadline =
     !projectId
       ? "Start by selecting a project"
+      : snapshotError
+        ? forecastLoadState?.title ?? "Forecast temporarily unavailable"
       : stats.totalGapHours > 0
         ? `${stats.totalGapHours}h still unbooked`
         : hasForecast
@@ -680,11 +777,20 @@ export default function LookaheadDashboard() {
   const focusDescription =
     !projectId
       ? "Choose a project and upload a programme to turn this into a planning workspace."
+      : snapshotError
+        ? forecastLoadState?.message ??
+          "The latest planning forecast could not be loaded right now."
       : stats.totalGapHours > 0
         ? "Use the heatmap to open the weekly activity behind the gap, then book directly from context."
         : hasForecast
           ? "Use the heatmap below to confirm activity coverage and spot changes early."
           : "This project needs a fresh programme upload before the heatmap can drive planning.";
+  const emptyForecastTitle = hydratedLatestUploadDate
+    ? "No forecast demand in this view yet"
+    : undefined;
+  const emptyForecastMessage = hydratedLatestUploadDate
+    ? `The latest upload from ${hydratedLatestUploadDate} is on file, but it did not produce forecast demand for the current heatmap view yet. Review the upload details or try another version.`
+    : undefined;
 
   return (
     <div className="min-h-screen bg-(--page-bg) p-4 font-sans sm:p-6 lg:p-8">
@@ -773,34 +879,49 @@ export default function LookaheadDashboard() {
                   )}
                 </div>
 
-                <Button
-                  disabled={!topActionButtonsReady || !projectId || isUploadInFlight}
-                  onClick={() => {
-                    if (isUploadInFlight) return;
-                    if (fileInputRef.current) fileInputRef.current.value = "";
-                    fileInputRef.current?.click();
-                  }}
-                  className="h-auto w-full rounded-lg bg-navy px-5 py-5 text-sm font-bold text-white shadow-md shadow-slate-900/10 hover:bg-(--navy-hover) sm:w-auto"
-                >
-                  <span className="flex items-center gap-2">
-                    {uploadPhase.kind === "uploading" || uploadPhase.kind === "polling" ? (
-                      <Loader2 size={15} className="animate-spin" />
-                    ) : (
-                      <Upload size={15} />
-                    )}
-                    Upload Programme
-                  </span>
-                </Button>
+                {hasMounted ? (
+                  <>
+                    <Button
+                      disabled={!topActionButtonsReady || !projectId || isUploadInFlight}
+                      onClick={() => {
+                        if (isUploadInFlight) return;
+                        if (fileInputRef.current) fileInputRef.current.value = "";
+                        fileInputRef.current?.click();
+                      }}
+                      className="h-auto w-full rounded-lg bg-navy px-5 py-5 text-sm font-bold text-white shadow-md shadow-slate-900/10 hover:bg-(--navy-hover) sm:w-auto"
+                    >
+                      <span className="flex items-center gap-2">
+                        {uploadPhase.kind === "uploading" || uploadPhase.kind === "polling" ? (
+                          <Loader2 size={15} className="animate-spin" />
+                        ) : (
+                          <Upload size={15} />
+                        )}
+                        Upload Programme
+                      </span>
+                    </Button>
 
-                <Button
-                  type="button"
-                  variant="outline"
-                  disabled={!topActionButtonsReady || !latestVersion}
-                  onClick={() => setIsUploadReviewOpen(true)}
-                  className="h-auto rounded-lg px-5 py-5 text-sm font-bold"
-                >
-                  Review latest upload
-                </Button>
+                    <Button
+                      type="button"
+                      variant="outline"
+                      disabled={!topActionButtonsReady || !latestVersion}
+                      onClick={() => setIsUploadReviewOpen(true)}
+                      className="h-auto rounded-lg px-5 py-5 text-sm font-bold"
+                    >
+                      Review latest upload
+                    </Button>
+                  </>
+                ) : (
+                  <>
+                    <div
+                      aria-hidden="true"
+                      className="h-[60px] w-full rounded-lg border border-slate-200 bg-slate-50 sm:w-[180px]"
+                    />
+                    <div
+                      aria-hidden="true"
+                      className="h-[60px] w-full rounded-lg border border-slate-200 bg-slate-50 sm:w-[220px]"
+                    />
+                  </>
+                )}
 
                 <input
                   ref={fileInputRef}
@@ -924,7 +1045,9 @@ export default function LookaheadDashboard() {
                 <WindowSelector
                   windowSize={windowSize}
                   onSetWindowSize={updateWindowSize}
-                  lastUpdated={versionsLoading ? null : latestUploadDate}
+                  lastUpdated={
+                    hasMounted && !versionsLoading ? latestUploadDate : null
+                  }
                 />
 
                 {topAlert && (
@@ -1036,8 +1159,30 @@ export default function LookaheadDashboard() {
                 </div>
               ) : !projectId ? (
                 <EmptyForecastState reason="no-project" />
+              ) : snapshotError ? (
+                <EmptyForecastState
+                  reason="load-error"
+                  title={forecastLoadState?.title}
+                  message={forecastLoadState?.message}
+                  actionLabel="Retry forecast"
+                  onAction={() => {
+                    void refreshLookaheadWorkspace();
+                  }}
+                />
               ) : !heatmap || visibleWeeks.length === 0 ? (
-                <EmptyForecastState reason="no-data" />
+                <EmptyForecastState
+                  reason="no-data"
+                  title={emptyForecastTitle}
+                  message={emptyForecastMessage}
+                  actionLabel={hydratedLatestUploadDate ? "Review latest upload" : undefined}
+                  onAction={
+                    hydratedLatestUploadDate
+                      ? () => {
+                          setIsUploadReviewOpen(true);
+                        }
+                      : undefined
+                  }
+                />
               ) : (
                 <DemandHeatmap
                   heatmap={heatmap}
@@ -1135,6 +1280,7 @@ export default function LookaheadDashboard() {
               <div className="grid gap-4 xl:grid-cols-2">
                 <SnapshotHistoryPanel
                   history={history}
+                  currentSnapshot={snapshot}
                   isOpen={isSnapshotHistoryOpen}
                   onOpenChange={setIsSnapshotHistoryOpen}
                   isLoading={Boolean(

--- a/src/components/lookahead/SnapshotHistoryPanel.tsx
+++ b/src/components/lookahead/SnapshotHistoryPanel.tsx
@@ -1,12 +1,16 @@
 "use client";
 
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { ChevronDown, Database } from "lucide-react";
-import type { LookaheadSnapshotHistoryEntry } from "@/types";
+import type {
+  LookaheadSnapshotHistoryEntry,
+  LookaheadSnapshotResponse,
+} from "@/types";
 import { formatDate } from "./utils";
 
 interface Props {
   history: LookaheadSnapshotHistoryEntry[];
+  currentSnapshot?: LookaheadSnapshotResponse | null;
   isOpen?: boolean;
   onOpenChange?: (open: boolean) => void;
   isLoading?: boolean;
@@ -14,6 +18,7 @@ interface Props {
 
 export function SnapshotHistoryPanel({
   history,
+  currentSnapshot = null,
   isOpen: controlledOpen,
   onOpenChange,
   isLoading = false,
@@ -21,6 +26,11 @@ export function SnapshotHistoryPanel({
   const [uncontrolledOpen, setUncontrolledOpen] = useState(false);
   const isOpen = controlledOpen ?? uncontrolledOpen;
   const panelId = "snapshot-history-panel";
+
+  const currentSnapshotRowCount = useMemo(() => {
+    if (!currentSnapshot?.rows) return null;
+    return currentSnapshot.rows.length;
+  }, [currentSnapshot]);
 
   const setIsOpen = (next: boolean) => {
     if (controlledOpen === undefined) {
@@ -60,27 +70,47 @@ export function SnapshotHistoryPanel({
               No snapshot history available yet.
             </div>
           ) : (
-            history.map((entry, index) => (
-              <div
-                key={entry.snapshot_id || `${entry.snapshot_date || "snapshot"}-${index}`}
-                className="rounded-lg border border-slate-200 bg-white px-3 py-3 text-sm"
-              >
-                <div className="flex flex-wrap items-center justify-between gap-2">
-                  <div>
-                    <p className="font-medium text-slate-900">
-                      Snapshot {history.length - index}
-                    </p>
-                    <p className="text-xs text-slate-500">
-                      {formatDate(entry.snapshot_date || null)}
-                      {entry.timezone ? ` · ${entry.timezone}` : ""}
-                    </p>
+            history.map((entry, index) => {
+              const matchesCurrentSnapshot = Boolean(
+                currentSnapshot &&
+                  ((entry.snapshot_id &&
+                    currentSnapshot.snapshot_id &&
+                    entry.snapshot_id === currentSnapshot.snapshot_id) ||
+                    (entry.snapshot_date &&
+                      currentSnapshot.snapshot_date &&
+                      entry.snapshot_date === currentSnapshot.snapshot_date)),
+              );
+
+              const rowCount =
+                entry.row_count ??
+                (entry.rows.length > 0 ? entry.rows.length : null) ??
+                (matchesCurrentSnapshot ? currentSnapshotRowCount : null);
+
+              return (
+                <div
+                  key={
+                    entry.snapshot_id ||
+                    `${entry.snapshot_date || "snapshot"}-${index}`
+                  }
+                  className="rounded-lg border border-slate-200 bg-white px-3 py-3 text-sm"
+                >
+                  <div className="flex flex-wrap items-center justify-between gap-2">
+                    <div>
+                      <p className="font-medium text-slate-900">
+                        Snapshot {history.length - index}
+                      </p>
+                      <p className="text-xs text-slate-500">
+                        {formatDate(entry.snapshot_date || null)}
+                        {entry.timezone ? ` · ${entry.timezone}` : ""}
+                      </p>
+                    </div>
+                    <span className="rounded-full bg-slate-100 px-2 py-0.5 text-[10px] font-semibold text-slate-600">
+                      {rowCount == null ? "Row count unavailable" : `${rowCount} rows`}
+                    </span>
                   </div>
-                  <span className="rounded-full bg-slate-100 px-2 py-0.5 text-[10px] font-semibold text-slate-600">
-                    {entry.rows.length} rows
-                  </span>
                 </div>
-              </div>
-            ))
+              );
+            })
           )}
         </div>
       )}

--- a/src/components/lookahead/UploadReviewDialog.tsx
+++ b/src/components/lookahead/UploadReviewDialog.tsx
@@ -1,7 +1,17 @@
 "use client";
 
-import { useMemo, useState } from "react";
-import { Coins, FileWarning, Loader2, Sparkles } from "lucide-react";
+import { useDeferredValue, useEffect, useMemo, useState } from "react";
+import {
+  CheckCircle2,
+  ChevronLeft,
+  ChevronRight,
+  Coins,
+  FileWarning,
+  Loader2,
+  Search,
+  Sparkles,
+  Zap,
+} from "lucide-react";
 import type {
   ActivityMappingResponse,
   ProgrammeUploadDiagnostics,
@@ -19,7 +29,20 @@ import {
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { ASSET_TYPE_OPTIONS } from "@/lib/formOptions";
 import { reportError } from "@/lib/monitoring";
+import { formatAssetType } from "./utils";
+
+/* ------------------------------------------------------------------ */
+/*  Types                                                              */
+/* ------------------------------------------------------------------ */
 
 interface Props {
   open: boolean;
@@ -33,9 +56,18 @@ interface Props {
   onPromoteToMemory: (itemId: string, assetType: string) => Promise<void>;
 }
 
+/* ------------------------------------------------------------------ */
+/*  Constants                                                          */
+/* ------------------------------------------------------------------ */
+
+const REVIEW_PAGE_SIZE = 25;
+
+/* ------------------------------------------------------------------ */
+/*  Helpers                                                            */
+/* ------------------------------------------------------------------ */
+
 function diagnosticBadges(notes?: ProgrammeUploadDiagnostics | null) {
   if (!notes) return [];
-
   return [
     notes.classification_ai_suppressed || notes.work_profile_ai_suppressed
       ? "AI suppressed"
@@ -45,13 +77,98 @@ function diagnosticBadges(notes?: ProgrammeUploadDiagnostics | null) {
       ? `${notes.unclassified_mapping_count} unclassified`
       : null,
     (notes.non_planning_ready_asset_count ?? 0) > 0
-      ? `${notes.non_planning_ready_asset_count} non-ready assets`
+      ? `${notes.non_planning_ready_asset_count} non‑ready assets`
       : null,
     (notes.excluded_booking_count ?? 0) > 0
       ? `${notes.excluded_booking_count} excluded bookings`
       : null,
-  ].filter((value): value is string => Boolean(value));
+  ].filter((v): v is string => Boolean(v));
 }
+
+function getCurrentMappingLabel(m: ActivityMappingResponse): string {
+  return (
+    m.asset_type ||
+    m.classification_name ||
+    m.current_classification ||
+    "Unclassified"
+  );
+}
+
+function getInitialDraft(m: ActivityMappingResponse): string {
+  return (
+    m.suggested_classification ||
+    m.asset_type ||
+    m.classification_name ||
+    m.current_classification ||
+    ""
+  );
+}
+
+function normalizeOptions(values: Array<string | null | undefined>): string[] {
+  const unique = new Set<string>();
+  for (const v of values) {
+    const t = v?.trim();
+    if (t) unique.add(t);
+  }
+  return Array.from(unique).sort((a, b) =>
+    formatAssetType(a).localeCompare(formatAssetType(b)),
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/*  Sub‑components                                                     */
+/* ------------------------------------------------------------------ */
+
+function StatCard({
+  label,
+  children,
+  toneClass = "border-slate-200 bg-white",
+}: {
+  label: string;
+  children: React.ReactNode;
+  toneClass?: string;
+}) {
+  return (
+    <div
+      className={`flex h-full min-w-0 flex-col justify-between rounded-2xl border px-5 py-4 shadow-sm ${toneClass}`}
+    >
+      <p className="text-xs font-semibold uppercase tracking-widest text-slate-500">
+        {label}
+      </p>
+      <div className="mt-1.5">{children}</div>
+    </div>
+  );
+}
+
+function StepHint({
+  step,
+  title,
+  description,
+}: {
+  step: number;
+  title: string;
+  description: string;
+}) {
+  return (
+    <div className="flex items-start gap-3">
+      <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-slate-900 text-xs font-bold text-white">
+        {step}
+      </span>
+      <div>
+        <p className="text-sm font-semibold leading-tight text-slate-800">
+          {title}
+        </p>
+        <p className="mt-0.5 text-sm leading-snug text-slate-500">
+          {description}
+        </p>
+      </div>
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/*  Main component                                                     */
+/* ------------------------------------------------------------------ */
 
 export function UploadReviewDialog({
   open,
@@ -68,239 +185,545 @@ export function UploadReviewDialog({
   const [busyId, setBusyId] = useState<string | null>(null);
   const [memoryBusyId, setMemoryBusyId] = useState<string | null>(null);
   const [actionErrors, setActionErrors] = useState<Record<string, string>>({});
+  const [searchTerm, setSearchTerm] = useState("");
+  const [page, setPage] = useState(1);
+
   const isAdmin = userRole === "admin";
   const notes = status?.completeness_notes;
   const badges = diagnosticBadges(notes);
+  const deferredSearch = useDeferredValue(searchTerm);
+
+  /* ---- derived data ---- */
 
   const reviewRows = useMemo(
     () => (unclassifiedMappings.length > 0 ? unclassifiedMappings : mappings),
     [mappings, unclassifiedMappings],
   );
 
+  const baseCorrectionOptions = useMemo(
+    () =>
+      normalizeOptions([
+        ...reviewRows.flatMap((m) => [
+          m.asset_type,
+          m.classification_name,
+          m.current_classification,
+          m.suggested_classification,
+        ]),
+        ...ASSET_TYPE_OPTIONS,
+      ]),
+    [reviewRows],
+  );
+
+  const correctionOptions = useMemo(
+    () => normalizeOptions([...baseCorrectionOptions, ...Object.values(drafts)]),
+    [baseCorrectionOptions, drafts],
+  );
+
+  const filteredRows = useMemo(() => {
+    const q = deferredSearch.trim().toLowerCase();
+    if (!q) return reviewRows;
+    return reviewRows.filter((m) =>
+      [
+        m.activity_name,
+        m.source_value,
+        m.asset_type,
+        m.classification_name,
+        m.current_classification,
+        m.suggested_classification,
+        m.level_name,
+        m.zone_name,
+      ].some((v) => v?.toLowerCase().includes(q)),
+    );
+  }, [deferredSearch, reviewRows]);
+
+  useEffect(() => {
+    if (open) setPage(1);
+  }, [deferredSearch, open]);
+
+  const totalPages = Math.max(
+    1,
+    Math.ceil(filteredRows.length / REVIEW_PAGE_SIZE),
+  );
+
+  useEffect(() => {
+    setPage((p) => Math.min(p, totalPages));
+  }, [totalPages]);
+
+  const visibleRows = useMemo(() => {
+    const start = (page - 1) * REVIEW_PAGE_SIZE;
+    return filteredRows.slice(start, start + REVIEW_PAGE_SIZE);
+  }, [filteredRows, page]);
+
+  const rangeStart =
+    filteredRows.length === 0 ? 0 : (page - 1) * REVIEW_PAGE_SIZE + 1;
+  const rangeEnd = Math.min(page * REVIEW_PAGE_SIZE, filteredRows.length);
+
+  /* ---- actions ---- */
+
+  async function handleCorrect(mapping: ActivityMappingResponse, value: string) {
+    const key = `mapping:${mapping.id}`;
+    setBusyId(mapping.id);
+    try {
+      await onCorrectMapping(mapping.id, value);
+      setActionErrors((prev) => {
+        const next = { ...prev };
+        delete next[key];
+        return next;
+      });
+    } catch (err) {
+      reportError(err, "UploadReviewDialog: failed to correct mapping");
+      setActionErrors((prev) => ({ ...prev, [key]: getApiErrorMessage(err) }));
+    } finally {
+      setBusyId(null);
+    }
+  }
+
+  async function handlePromote(itemId: string, value: string) {
+    const key = `memory:${itemId}`;
+    setMemoryBusyId(itemId);
+    try {
+      await onPromoteToMemory(itemId, value);
+      setActionErrors((prev) => {
+        const next = { ...prev };
+        delete next[key];
+        return next;
+      });
+    } catch (err) {
+      reportError(err, "UploadReviewDialog: failed to promote mapping memory");
+      setActionErrors((prev) => ({ ...prev, [key]: getApiErrorMessage(err) }));
+    } finally {
+      setMemoryBusyId(null);
+    }
+  }
+
+  /* ---------------------------------------------------------------- */
+  /*  Render                                                           */
+  /* ---------------------------------------------------------------- */
+
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="w-[calc(100vw-1rem)] max-w-5xl bg-white">
-        <DialogHeader>
-          <DialogTitle>Upload review</DialogTitle>
-          <DialogDescription className="text-sm text-slate-500">
-            Review diagnostics, mapping confidence, and upload-local corrections
-            for the latest programme import.
-          </DialogDescription>
-        </DialogHeader>
+      <DialogContent className="flex h-[92vh] w-full max-w-screen-2xl flex-col overflow-hidden rounded-2xl border-0 bg-slate-50 p-0 shadow-2xl">
+        {/* ─── HEADER ─── */}
+        <div className="shrink-0 border-b border-slate-200 bg-white px-8 pb-5 pt-7">
+          <DialogHeader className="space-y-1">
+            <DialogTitle className="text-2xl font-extrabold tracking-tight text-slate-950">
+              Upload review
+            </DialogTitle>
+            <DialogDescription className="max-w-2xl text-sm leading-relaxed text-slate-500">
+              Match each programme row to its correct asset type. Apply fixes to
+              this upload, or save them for all future imports.
+            </DialogDescription>
+          </DialogHeader>
+        </div>
 
-        {status && (
-          <div className="grid gap-3 md:grid-cols-4">
-            <div className="rounded-xl border border-slate-200 bg-slate-50 p-3">
-              <p className="text-[11px] uppercase tracking-wide text-slate-500">Completeness</p>
-              <p className="mt-1 text-2xl font-bold text-slate-900">
-                {status.completeness_score}%
+        {/* ─── SCROLLABLE BODY ─── */}
+        <div className="flex min-h-0 flex-1 flex-col gap-6 overflow-y-auto overscroll-contain px-8 py-6">
+          {/* ── Stats ── */}
+          {status && (
+            <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+              <StatCard label="Completeness">
+                <p className="text-3xl font-black leading-none text-slate-950">
+                  {status.completeness_score}
+                  <span className="text-lg font-bold text-slate-400">%</span>
+                </p>
+              </StatCard>
+
+              <StatCard label="Status">
+                <p className="break-words text-base font-bold capitalize leading-tight text-slate-950 sm:text-lg">
+                  {status.status}
+                </p>
+              </StatCard>
+
+              <StatCard label="AI telemetry">
+                <div className="space-y-1.5 text-sm text-slate-700">
+                  <span className="flex items-center gap-1.5">
+                    <Sparkles className="h-3.5 w-3.5 text-slate-400" />
+                    {status.ai_tokens_used ?? 0} tokens
+                  </span>
+                  <span className="flex items-center gap-1.5">
+                    <Coins className="h-3.5 w-3.5 text-slate-400" />$
+                    {(status.ai_cost_usd ?? 0).toFixed(2)}
+                  </span>
+                </div>
+              </StatCard>
+
+              <StatCard label="Needs review">
+                <p className="text-3xl font-black leading-none text-slate-950">
+                  {reviewRows.length}
+                </p>
+              </StatCard>
+            </div>
+          )}
+
+          {/* ── Diagnostic badges ── */}
+          {badges.length > 0 && (
+            <div className="flex flex-wrap gap-1.5">
+              {badges.map((b) => (
+                <Badge
+                  key={b}
+                  variant="secondary"
+                  className="gap-1 bg-amber-50 text-amber-700 hover:bg-amber-100"
+                >
+                  <FileWarning className="h-3 w-3" />
+                  {b}
+                </Badge>
+              ))}
+            </div>
+          )}
+
+          {/* ── Notes banner ── */}
+          {notes?.notes && (
+            <div className="rounded-xl border border-amber-200 bg-amber-50/80 px-5 py-3.5 text-sm leading-relaxed text-amber-800">
+              {Array.isArray(notes.notes) ? notes.notes.join(" ") : notes.notes}
+            </div>
+          )}
+
+          {/* ── How‑to steps (compact) ── */}
+          <div className="rounded-xl border border-slate-200 bg-white p-5">
+            <div className="grid gap-5 lg:grid-cols-3">
+              <StepHint
+                step={1}
+                title="Read the source row"
+                description="Use the activity name and location to identify the required plant or equipment."
+              />
+              <StepHint
+                step={2}
+                title="Choose the asset type"
+                description="Pick from the suggested or known types. Add a custom type only if nothing matches."
+              />
+              <StepHint
+                step={3}
+                title="Save at the right scope"
+                description={`"Apply" fixes this import only.${isAdmin ? " Admins can also save mappings for future uploads." : ""}`}
+              />
+            </div>
+          </div>
+
+          {/* ── Toolbar: search + pagination ── */}
+          <div className="flex flex-col gap-3 rounded-xl border border-slate-200 bg-white p-4 lg:flex-row lg:items-center lg:justify-between">
+            <div className="relative w-full sm:max-w-xs lg:max-w-72">
+              <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-400" />
+              <Input
+                value={searchTerm}
+                onChange={(e) => setSearchTerm(e.target.value)}
+                placeholder="Search activity, location, or type…"
+                  className="h-9 rounded-lg border-slate-200 bg-slate-50 pl-9 text-sm placeholder:text-slate-400 focus-visible:bg-white"
+              />
+            </div>
+
+            <div className="flex items-center gap-3">
+              <p className="whitespace-nowrap text-sm text-slate-500">
+                {filteredRows.length === 0
+                  ? "No rows"
+                  : `${rangeStart}–${rangeEnd} of ${filteredRows.length}`}
+                {filteredRows.length !== reviewRows.length && (
+                  <span className="text-slate-400">
+                    {" "}
+                    (from {reviewRows.length})
+                  </span>
+                )}
+              </p>
+
+              <div className="flex items-center gap-1">
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="icon"
+                  className="h-8 w-8 rounded-lg"
+                  disabled={page <= 1}
+                  onClick={() => setPage((p) => Math.max(1, p - 1))}
+                >
+                  <ChevronLeft className="h-4 w-4" />
+                </Button>
+                <span className="min-w-14 text-center text-sm font-medium text-slate-700">
+                  {page}/{totalPages}
+                </span>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="icon"
+                  className="h-8 w-8 rounded-lg"
+                  disabled={page >= totalPages}
+                  onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+                >
+                  <ChevronRight className="h-4 w-4" />
+                </Button>
+              </div>
+            </div>
+          </div>
+
+          {/* ── List body ── */}
+          {isLoading ? (
+            <div className="flex min-h-70 flex-col items-center justify-center gap-3 rounded-xl border border-dashed border-slate-200 bg-white text-slate-400">
+              <Loader2 className="h-6 w-6 animate-spin" />
+              <p className="text-sm font-medium">Loading review data…</p>
+            </div>
+          ) : reviewRows.length === 0 ? (
+            <div className="flex min-h-70 flex-col items-center justify-center gap-2 rounded-xl border border-dashed border-slate-200 bg-white p-8 text-center">
+              <CheckCircle2 className="h-8 w-8 text-emerald-400" />
+              <p className="text-sm font-medium text-slate-700">
+                All clear — no mapping issues found
+              </p>
+              <p className="text-sm text-slate-400">
+                Every row in this upload has been classified.
               </p>
             </div>
-            <div className="rounded-xl border border-slate-200 bg-slate-50 p-3">
-              <p className="text-[11px] uppercase tracking-wide text-slate-500">Status</p>
-              <p className="mt-1 text-lg font-bold text-slate-900 capitalize">{status.status}</p>
-            </div>
-            <div className="rounded-xl border border-slate-200 bg-slate-50 p-3">
-              <p className="text-[11px] uppercase tracking-wide text-slate-500">AI telemetry</p>
-              <p className="mt-1 text-sm text-slate-700">
-                <Sparkles className="mr-1 inline h-3.5 w-3.5" />
-                {status.ai_tokens_used ?? 0} tokens
+          ) : filteredRows.length === 0 ? (
+            <div className="flex min-h-70 flex-col items-center justify-center gap-2 rounded-xl border border-dashed border-slate-200 bg-white p-8 text-center">
+              <Search className="h-7 w-7 text-slate-300" />
+              <p className="text-sm font-medium text-slate-700">
+                No rows match your search
               </p>
-              <p className="text-sm text-slate-700">
-                <Coins className="mr-1 inline h-3.5 w-3.5" />$
-                {(status.ai_cost_usd ?? 0).toFixed(2)}
+              <p className="text-sm text-slate-400">
+                Try a different keyword or clear the search field.
               </p>
             </div>
-            <div className="rounded-xl border border-slate-200 bg-slate-50 p-3">
-              <p className="text-[11px] uppercase tracking-wide text-slate-500">Needs review</p>
-              <p className="mt-1 text-lg font-bold text-amber-700">
-                {reviewRows.length}
-              </p>
-            </div>
-          </div>
-        )}
+          ) : (
+            <div className="space-y-3 pb-2">
+              {visibleRows.map((mapping) => {
+                const draft =
+                  drafts[mapping.id] ?? getInitialDraft(mapping);
+                const trimmed = draft.trim();
+                const current = getCurrentMappingLabel(mapping);
+                const suggested =
+                  mapping.suggested_classification?.trim();
+                const mapErr = actionErrors[`mapping:${mapping.id}`];
+                const memErr = mapping.item_id
+                  ? actionErrors[`memory:${mapping.item_id}`]
+                  : undefined;
 
-        {badges.length > 0 && (
-          <div className="flex flex-wrap gap-2">
-            {badges.map((badge) => (
-              <Badge key={badge} variant="secondary">
-                <FileWarning className="mr-1 h-3 w-3" />
-                {badge}
-              </Badge>
-            ))}
-          </div>
-        )}
-
-        {notes?.notes && (
-          <div className="rounded-xl border border-amber-200 bg-amber-50 p-3 text-sm text-amber-800">
-            {Array.isArray(notes.notes) ? notes.notes.join(" ") : notes.notes}
-          </div>
-        )}
-
-        {isLoading ? (
-          <div className="flex min-h-60 items-center justify-center text-slate-500">
-            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-            Loading review data...
-          </div>
-        ) : reviewRows.length === 0 ? (
-          <div className="rounded-xl border border-dashed border-slate-200 bg-slate-50 p-8 text-center text-sm text-slate-500">
-            No mapping issues were returned for this upload.
-          </div>
-        ) : (
-          <div className="max-h-[60vh] overflow-auto rounded-xl border border-slate-200">
-            <table className="min-w-full divide-y divide-slate-200 text-sm">
-              <thead className="bg-slate-50 text-left text-xs uppercase tracking-wide text-slate-500">
-                <tr>
-                  <th className="px-3 py-2">Source row</th>
-                  <th className="px-3 py-2">Current mapping</th>
-                  <th className="px-3 py-2">Provenance</th>
-                  <th className="px-3 py-2">Correction</th>
-                </tr>
-              </thead>
-              <tbody className="divide-y divide-slate-200 bg-white">
-                {reviewRows.map((mapping) => {
-                  const draft = drafts[mapping.id] ?? mapping.asset_type ?? "";
-                  return (
-                    <tr key={mapping.id}>
-                      <td className="px-3 py-3 align-top">
-                        <p className="font-medium text-slate-900">
-                          {mapping.activity_name || mapping.source_value || "Mapping row"}
-                        </p>
-                        {(mapping.level_name || mapping.zone_name) && (
-                          <p className="mt-1 text-xs text-slate-500">
-                            {[mapping.level_name, mapping.zone_name].filter(Boolean).join(" · ")}
+                return (
+                  <div
+                    key={mapping.id}
+                    className="overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm transition-shadow hover:shadow-md"
+                  >
+                    <div className="grid divide-y divide-slate-100 lg:grid-cols-5 lg:divide-x lg:divide-y-0">
+                      {/* ── Left: source info ── */}
+                      <div className="space-y-4 p-5 lg:col-span-3">
+                        {/* Title + location */}
+                        <div>
+                          <p className="text-base font-semibold leading-snug text-slate-900">
+                            {mapping.activity_name ||
+                              mapping.source_value ||
+                              "Unnamed row"}
                           </p>
-                        )}
-                      </td>
-                      <td className="px-3 py-3 align-top">
-                        <p className="text-slate-700">
-                          {mapping.asset_type ||
-                            mapping.classification_name ||
-                            "Unclassified"}
-                        </p>
-                      </td>
-                      <td className="px-3 py-3 align-top">
-                        <div className="space-y-1 text-xs text-slate-500">
-                          <p>Source: {mapping.source || "Unknown"}</p>
-                          <p>
-                            Confidence:{" "}
-                            {mapping.confidence != null
-                              ? `${Math.round(mapping.confidence * 100)}%`
-                              : "n/a"}
-                          </p>
-                          <p>
-                            Manual: {mapping.manual_correction ? "Yes" : "No"}
-                          </p>
-                          {mapping.corrected_by && (
-                            <p>
-                              Corrected by {mapping.corrected_by}
-                              {mapping.corrected_at ? ` on ${mapping.corrected_at}` : ""}
+                          {(mapping.level_name || mapping.zone_name) && (
+                            <p className="mt-1 text-sm text-slate-500">
+                              {[mapping.level_name, mapping.zone_name]
+                                .filter(Boolean)
+                                .join(" · ")}
                             </p>
                           )}
                         </div>
-                      </td>
-                      <td className="px-3 py-3 align-top">
-                        <div className="flex flex-col gap-2 sm:flex-row">
-                          <Input
-                            value={draft}
-                            onChange={(event) =>
-                              setDrafts((current) => ({
-                                ...current,
-                                [mapping.id]: event.target.value,
+
+                        {/* Badges */}
+                        <div className="flex flex-wrap gap-1.5">
+                          <Badge
+                            variant="secondary"
+                            className="rounded-md bg-slate-100 text-slate-600"
+                          >
+                            Current:{" "}
+                            {formatAssetType(current)}
+                          </Badge>
+                          {suggested && (
+                            <Badge className="rounded-md border-0 bg-teal-50 text-teal-700 hover:bg-teal-100">
+                              <Zap className="mr-0.5 h-3 w-3" />
+                              Suggested:{" "}
+                              {formatAssetType(suggested)}
+                            </Badge>
+                          )}
+                          {mapping.manual_correction && (
+                            <Badge
+                              variant="outline"
+                              className="rounded-md text-slate-500"
+                            >
+                              Manually corrected
+                            </Badge>
+                          )}
+                        </div>
+
+                        {/* Meta */}
+                        <div className="flex flex-wrap gap-x-5 gap-y-1 text-sm text-slate-500">
+                          <span>
+                            Source:{" "}
+                            <span className="font-medium text-slate-700">
+                              {mapping.source || "Unknown"}
+                            </span>
+                          </span>
+                          <span>
+                            Confidence:{" "}
+                            <span className="font-medium text-slate-700">
+                              {mapping.confidence != null
+                                ? `${Math.round(mapping.confidence * 100)}%`
+                                : "n/a"}
+                            </span>
+                          </span>
+                          {mapping.corrected_by && (
+                            <span>
+                              Changed by{" "}
+                              <span className="font-medium text-slate-700">
+                                {mapping.corrected_by}
+                              </span>
+                            </span>
+                          )}
+                        </div>
+                      </div>
+
+                      {/* ── Right: action panel ── */}
+                      <div className="space-y-4 bg-slate-50/60 p-5 lg:col-span-2">
+                        <p className="text-xs font-semibold uppercase tracking-widest text-slate-400">
+                          Assign asset type
+                        </p>
+
+                        {/* Dropdown */}
+                        <Select
+                          value={trimmed || undefined}
+                          onValueChange={(v) =>
+                            setDrafts((prev) => ({
+                              ...prev,
+                              [mapping.id]: v,
+                            }))
+                          }
+                        >
+                          <SelectTrigger className="h-9 w-full max-w-full rounded-lg border-slate-200 bg-white text-sm sm:max-w-72">
+                            <SelectValue placeholder="Choose an asset type" />
+                          </SelectTrigger>
+                          <SelectContent>
+                            {correctionOptions.map((opt) => (
+                              <SelectItem key={opt} value={opt}>
+                                {formatAssetType(opt)}
+                              </SelectItem>
+                            ))}
+                          </SelectContent>
+                        </Select>
+
+                        {/* Custom input */}
+                        <Input
+                          value={draft}
+                          onChange={(e) =>
+                            setDrafts((prev) => ({
+                              ...prev,
+                              [mapping.id]: e.target.value,
+                            }))
+                          }
+                          placeholder="Or type a custom asset type…"
+                          className="h-9 w-full max-w-full rounded-lg border-slate-200 bg-white text-sm sm:max-w-72"
+                        />
+
+                        {/* Quick‑fill suggestion */}
+                        {suggested && trimmed !== suggested && (
+                          <button
+                            type="button"
+                            onClick={() =>
+                              setDrafts((prev) => ({
+                                ...prev,
+                                [mapping.id]: suggested,
                               }))
                             }
-                            placeholder="e.g. scissor_lift"
-                            className="max-w-xs"
-                          />
+                            className="inline-flex items-center gap-1 rounded-md bg-teal-50 px-2.5 py-1.5 text-xs font-medium text-teal-700 transition-colors hover:bg-teal-100"
+                          >
+                            <Zap className="h-3 w-3" />
+                            Use suggested: {formatAssetType(suggested)}
+                          </button>
+                        )}
+
+                        {/* Action buttons */}
+                        <div className="flex flex-wrap gap-2 pt-1">
                           <Button
                             type="button"
                             size="sm"
-                            disabled={!draft.trim() || busyId === mapping.id}
-                            onClick={async () => {
-                              const trimmedDraft = draft.trim();
-                              const errorKey = `mapping:${mapping.id}`;
-                              setBusyId(mapping.id);
-                              try {
-                                await onCorrectMapping(mapping.id, trimmedDraft);
-                                setActionErrors((current) => {
-                                  const next = { ...current };
-                                  delete next[errorKey];
-                                  return next;
-                                });
-                              } catch (error) {
-                                reportError(
-                                  error,
-                                  "UploadReviewDialog: failed to correct mapping",
-                                );
-                                setActionErrors((current) => ({
-                                  ...current,
-                                  [errorKey]: getApiErrorMessage(error),
-                                }));
-                              } finally {
-                                setBusyId(null);
-                              }
-                            }}
+                            className="h-9 rounded-lg px-4 text-sm font-semibold"
+                            disabled={!trimmed || busyId === mapping.id}
+                            onClick={() => handleCorrect(mapping, trimmed)}
                           >
-                            {busyId === mapping.id ? "Saving..." : "Save correction"}
+                            {busyId === mapping.id ? (
+                              <>
+                                <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
+                                Saving…
+                              </>
+                            ) : (
+                              "Apply to this upload"
+                            )}
                           </Button>
+
                           {isAdmin && mapping.item_id && (
                             <Button
                               type="button"
                               size="sm"
                               variant="outline"
+                              className="h-9 rounded-lg px-4 text-sm font-semibold"
                               disabled={
-                                !draft.trim() || memoryBusyId === mapping.item_id
+                                !trimmed ||
+                                memoryBusyId === mapping.item_id
                               }
-                              onClick={async () => {
-                                const trimmedDraft = draft.trim();
-                                const memoryKey = `memory:${mapping.item_id}`;
-                                setMemoryBusyId(mapping.item_id || null);
-                                try {
-                                  await onPromoteToMemory(
-                                    mapping.item_id as string,
-                                    trimmedDraft,
-                                  );
-                                  setActionErrors((current) => {
-                                    const next = { ...current };
-                                    delete next[memoryKey];
-                                    return next;
-                                  });
-                                } catch (error) {
-                                  reportError(
-                                    error,
-                                    "UploadReviewDialog: failed to promote mapping memory",
-                                  );
-                                  setActionErrors((current) => ({
-                                    ...current,
-                                    [memoryKey]: getApiErrorMessage(error),
-                                  }));
-                                } finally {
-                                  setMemoryBusyId(null);
-                                }
-                              }}
+                              onClick={() =>
+                                handlePromote(
+                                  mapping.item_id as string,
+                                  trimmed,
+                                )
+                              }
                             >
-                              {memoryBusyId === mapping.item_id
-                                ? "Promoting..."
-                                : "Promote to memory"}
+                              {memoryBusyId === mapping.item_id ? (
+                                <>
+                                  <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
+                                  Saving…
+                                </>
+                              ) : (
+                                "Save for future uploads"
+                              )}
                             </Button>
                           )}
                         </div>
-                        {(actionErrors[`mapping:${mapping.id}`] ||
-                          (mapping.item_id &&
-                            actionErrors[`memory:${mapping.item_id}`])) && (
-                          <p className="mt-2 text-xs text-red-600">
-                            {actionErrors[`mapping:${mapping.id}`] ??
-                              actionErrors[`memory:${mapping.item_id}`]}
+
+                        {/* Error feedback */}
+                        {(mapErr || memErr) && (
+                          <p className="rounded-md bg-red-50 px-3 py-2 text-xs font-medium text-red-600">
+                            {mapErr ?? memErr}
                           </p>
                         )}
-                      </td>
-                    </tr>
-                  );
-                })}
-              </tbody>
-            </table>
-          </div>
-        )}
+                      </div>
+                    </div>
+                  </div>
+                );
+              })}
+
+              {/* ── Bottom pagination ── */}
+              {totalPages > 1 && (
+                <div className="flex items-center justify-between rounded-xl border border-slate-200 bg-white px-5 py-3">
+                  <p className="text-sm text-slate-500">
+                    Rows {rangeStart}–{rangeEnd} of {filteredRows.length}
+                  </p>
+                  <div className="flex items-center gap-1">
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      className="h-8 rounded-lg px-3 text-sm"
+                      disabled={page <= 1}
+                      onClick={() => setPage((p) => Math.max(1, p - 1))}
+                    >
+                      <ChevronLeft className="mr-1 h-3.5 w-3.5" />
+                      Previous
+                    </Button>
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      className="h-8 rounded-lg px-3 text-sm"
+                      disabled={page >= totalPages}
+                      onClick={() =>
+                        setPage((p) => Math.min(totalPages, p + 1))
+                      }
+                    >
+                      Next
+                      <ChevronRight className="ml-1 h-3.5 w-3.5" />
+                    </Button>
+                  </div>
+                </div>
+              )}
+            </div>
+          )}
+        </div>
       </DialogContent>
     </Dialog>
   );

--- a/src/components/lookahead/UploadReviewDialog.tsx
+++ b/src/components/lookahead/UploadReviewDialog.tsx
@@ -56,6 +56,12 @@ interface Props {
   onPromoteToMemory: (itemId: string, assetType: string) => Promise<void>;
 }
 
+interface PaginationControlsProps {
+  page: number;
+  totalPages: number;
+  setPage: React.Dispatch<React.SetStateAction<number>>;
+}
+
 /* ------------------------------------------------------------------ */
 /*  Constants                                                          */
 /* ------------------------------------------------------------------ */
@@ -166,6 +172,42 @@ function StepHint({
   );
 }
 
+function PaginationControls({
+  page,
+  totalPages,
+  setPage,
+}: PaginationControlsProps) {
+  return (
+    <div className="flex items-center gap-1">
+      <Button
+        type="button"
+        variant="outline"
+        size="icon"
+        className="h-8 w-8 rounded-lg"
+        aria-label="Previous page"
+        disabled={page <= 1}
+        onClick={() => setPage((p) => Math.max(1, p - 1))}
+      >
+        <ChevronLeft className="h-4 w-4" />
+      </Button>
+      <span className="min-w-14 text-center text-sm font-medium text-slate-700">
+        {page}/{totalPages}
+      </span>
+      <Button
+        type="button"
+        variant="outline"
+        size="icon"
+        className="h-8 w-8 rounded-lg"
+        aria-label="Next page"
+        disabled={page >= totalPages}
+        onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+      >
+        <ChevronRight className="h-4 w-4" />
+      </Button>
+    </div>
+  );
+}
+
 /* ------------------------------------------------------------------ */
 /*  Main component                                                     */
 /* ------------------------------------------------------------------ */
@@ -182,8 +224,8 @@ export function UploadReviewDialog({
   onPromoteToMemory,
 }: Props) {
   const [drafts, setDrafts] = useState<Record<string, string>>({});
-  const [busyId, setBusyId] = useState<string | null>(null);
-  const [memoryBusyId, setMemoryBusyId] = useState<string | null>(null);
+  const [mappingBusy, setMappingBusy] = useState<Record<string, boolean>>({});
+  const [memoryBusy, setMemoryBusy] = useState<Record<string, boolean>>({});
   const [actionErrors, setActionErrors] = useState<Record<string, string>>({});
   const [searchTerm, setSearchTerm] = useState("");
   const [page, setPage] = useState(1);
@@ -262,7 +304,8 @@ export function UploadReviewDialog({
 
   async function handleCorrect(mapping: ActivityMappingResponse, value: string) {
     const key = `mapping:${mapping.id}`;
-    setBusyId(mapping.id);
+    if (mappingBusy[mapping.id]) return;
+    setMappingBusy((prev) => ({ ...prev, [mapping.id]: true }));
     try {
       await onCorrectMapping(mapping.id, value);
       setActionErrors((prev) => {
@@ -274,13 +317,14 @@ export function UploadReviewDialog({
       reportError(err, "UploadReviewDialog: failed to correct mapping");
       setActionErrors((prev) => ({ ...prev, [key]: getApiErrorMessage(err) }));
     } finally {
-      setBusyId(null);
+      setMappingBusy((prev) => ({ ...prev, [mapping.id]: false }));
     }
   }
 
   async function handlePromote(itemId: string, value: string) {
     const key = `memory:${itemId}`;
-    setMemoryBusyId(itemId);
+    if (memoryBusy[itemId]) return;
+    setMemoryBusy((prev) => ({ ...prev, [itemId]: true }));
     try {
       await onPromoteToMemory(itemId, value);
       setActionErrors((prev) => {
@@ -292,7 +336,7 @@ export function UploadReviewDialog({
       reportError(err, "UploadReviewDialog: failed to promote mapping memory");
       setActionErrors((prev) => ({ ...prev, [key]: getApiErrorMessage(err) }));
     } finally {
-      setMemoryBusyId(null);
+      setMemoryBusy((prev) => ({ ...prev, [itemId]: false }));
     }
   }
 
@@ -424,31 +468,11 @@ export function UploadReviewDialog({
                 )}
               </p>
 
-              <div className="flex items-center gap-1">
-                <Button
-                  type="button"
-                  variant="outline"
-                  size="icon"
-                  className="h-8 w-8 rounded-lg"
-                  disabled={page <= 1}
-                  onClick={() => setPage((p) => Math.max(1, p - 1))}
-                >
-                  <ChevronLeft className="h-4 w-4" />
-                </Button>
-                <span className="min-w-14 text-center text-sm font-medium text-slate-700">
-                  {page}/{totalPages}
-                </span>
-                <Button
-                  type="button"
-                  variant="outline"
-                  size="icon"
-                  className="h-8 w-8 rounded-lg"
-                  disabled={page >= totalPages}
-                  onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
-                >
-                  <ChevronRight className="h-4 w-4" />
-                </Button>
-              </div>
+              <PaginationControls
+                page={page}
+                totalPages={totalPages}
+                setPage={setPage}
+              />
             </div>
           </div>
 
@@ -633,10 +657,10 @@ export function UploadReviewDialog({
                             type="button"
                             size="sm"
                             className="h-9 rounded-lg px-4 text-sm font-semibold"
-                            disabled={!trimmed || busyId === mapping.id}
+                            disabled={!trimmed || Boolean(mappingBusy[mapping.id])}
                             onClick={() => handleCorrect(mapping, trimmed)}
                           >
-                            {busyId === mapping.id ? (
+                            {mappingBusy[mapping.id] ? (
                               <>
                                 <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
                                 Saving…
@@ -654,7 +678,9 @@ export function UploadReviewDialog({
                               className="h-9 rounded-lg px-4 text-sm font-semibold"
                               disabled={
                                 !trimmed ||
-                                memoryBusyId === mapping.item_id
+                                Boolean(
+                                  mapping.item_id && memoryBusy[mapping.item_id],
+                                )
                               }
                               onClick={() =>
                                 handlePromote(
@@ -663,7 +689,7 @@ export function UploadReviewDialog({
                                 )
                               }
                             >
-                              {memoryBusyId === mapping.item_id ? (
+                              {mapping.item_id && memoryBusy[mapping.item_id] ? (
                                 <>
                                   <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
                                   Saving…
@@ -693,32 +719,11 @@ export function UploadReviewDialog({
                   <p className="text-sm text-slate-500">
                     Rows {rangeStart}–{rangeEnd} of {filteredRows.length}
                   </p>
-                  <div className="flex items-center gap-1">
-                    <Button
-                      type="button"
-                      variant="outline"
-                      size="sm"
-                      className="h-8 rounded-lg px-3 text-sm"
-                      disabled={page <= 1}
-                      onClick={() => setPage((p) => Math.max(1, p - 1))}
-                    >
-                      <ChevronLeft className="mr-1 h-3.5 w-3.5" />
-                      Previous
-                    </Button>
-                    <Button
-                      type="button"
-                      variant="outline"
-                      size="sm"
-                      className="h-8 rounded-lg px-3 text-sm"
-                      disabled={page >= totalPages}
-                      onClick={() =>
-                        setPage((p) => Math.min(totalPages, p + 1))
-                      }
-                    >
-                      Next
-                      <ChevronRight className="ml-1 h-3.5 w-3.5" />
-                    </Button>
-                  </div>
+                  <PaginationControls
+                    page={page}
+                    totalPages={totalPages}
+                    setPage={setPage}
+                  />
                 </div>
               )}
             </div>

--- a/src/components/lookahead/UploadReviewDialog.tsx
+++ b/src/components/lookahead/UploadReviewDialog.tsx
@@ -268,10 +268,10 @@ export function UploadReviewDialog({
       [
         m.activity_name,
         m.source_value,
-        m.asset_type,
-        m.classification_name,
-        m.current_classification,
-        m.suggested_classification,
+        m.asset_type ? formatAssetType(m.asset_type) : null,
+        m.classification_name ? formatAssetType(m.classification_name) : null,
+        m.current_classification ? formatAssetType(m.current_classification) : null,
+        m.suggested_classification ? formatAssetType(m.suggested_classification) : null,
         m.level_name,
         m.zone_name,
       ].some((v) => v?.toLowerCase().includes(q)),
@@ -286,19 +286,20 @@ export function UploadReviewDialog({
     1,
     Math.ceil(filteredRows.length / REVIEW_PAGE_SIZE),
   );
+  const clampedPage = Math.max(1, Math.min(page, totalPages));
 
   useEffect(() => {
     setPage((p) => Math.min(p, totalPages));
   }, [totalPages]);
 
   const visibleRows = useMemo(() => {
-    const start = (page - 1) * REVIEW_PAGE_SIZE;
+    const start = (clampedPage - 1) * REVIEW_PAGE_SIZE;
     return filteredRows.slice(start, start + REVIEW_PAGE_SIZE);
-  }, [filteredRows, page]);
+  }, [clampedPage, filteredRows]);
 
   const rangeStart =
-    filteredRows.length === 0 ? 0 : (page - 1) * REVIEW_PAGE_SIZE + 1;
-  const rangeEnd = Math.min(page * REVIEW_PAGE_SIZE, filteredRows.length);
+    filteredRows.length === 0 ? 0 : (clampedPage - 1) * REVIEW_PAGE_SIZE + 1;
+  const rangeEnd = Math.min(clampedPage * REVIEW_PAGE_SIZE, filteredRows.length);
 
   /* ---- actions ---- */
 
@@ -373,7 +374,7 @@ export function UploadReviewDialog({
               </StatCard>
 
               <StatCard label="Status">
-                <p className="break-words text-base font-bold capitalize leading-tight text-slate-950 sm:text-lg">
+                <p className="wrap-break-word text-base font-bold capitalize leading-tight text-slate-950 sm:text-lg">
                   {status.status}
                 </p>
               </StatCard>
@@ -450,6 +451,7 @@ export function UploadReviewDialog({
               <Input
                 value={searchTerm}
                 onChange={(e) => setSearchTerm(e.target.value)}
+                aria-label="Search activities, locations, or types"
                 placeholder="Search activity, location, or type…"
                   className="h-9 rounded-lg border-slate-200 bg-slate-50 pl-9 text-sm placeholder:text-slate-400 focus-visible:bg-white"
               />
@@ -469,7 +471,7 @@ export function UploadReviewDialog({
               </p>
 
               <PaginationControls
-                page={page}
+                page={clampedPage}
                 totalPages={totalPages}
                 setPage={setPage}
               />
@@ -631,6 +633,11 @@ export function UploadReviewDialog({
                             }))
                           }
                           placeholder="Or type a custom asset type…"
+                          aria-label={`Custom asset type for ${
+                            mapping.activity_name ||
+                            mapping.source_value ||
+                            "this mapping row"
+                          }`}
                           className="h-9 w-full max-w-full rounded-lg border-slate-200 bg-white text-sm sm:max-w-72"
                         />
 
@@ -720,7 +727,7 @@ export function UploadReviewDialog({
                     Rows {rangeStart}–{rangeEnd} of {filteredRows.length}
                   </p>
                   <PaginationControls
-                    page={page}
+                    page={clampedPage}
                     totalPages={totalPages}
                     setPage={setPage}
                   />

--- a/src/hooks/lookahead/api.test.ts
+++ b/src/hooks/lookahead/api.test.ts
@@ -11,6 +11,7 @@ vi.mock("@/lib/api", () => ({
 }));
 
 import {
+  fetchLookaheadHistory,
   fetchPlanningCompleteness,
   fetchProgrammeActivityBookingContext,
 } from "@/hooks/lookahead/api";
@@ -184,5 +185,40 @@ describe("lookahead api", () => {
       title: "Resolve unknown asset types",
       link: "/assets?filter=review",
     });
+  });
+
+  it("preserves snapshot history row counts when rows are summarized", async () => {
+    getMock.mockResolvedValueOnce({
+      data: {
+        history: [
+          {
+            snapshot_id: "snapshot-3",
+            snapshot_date: "2026-03-28",
+            timezone: "Australia/Sydney",
+            row_count: 42,
+          },
+          {
+            snapshot_id: "snapshot-2",
+            snapshot_date: "2026-03-27",
+            timezone: "Australia/Sydney",
+            rows: [{ asset_type: "Crane" }],
+          },
+        ],
+      },
+    });
+
+    const history = await fetchLookaheadHistory("project-1");
+
+    expect(history).toMatchObject([
+      {
+        snapshot_id: "snapshot-3",
+        row_count: 42,
+        rows: [],
+      },
+      {
+        snapshot_id: "snapshot-2",
+        row_count: 1,
+      },
+    ]);
   });
 });

--- a/src/hooks/lookahead/api.ts
+++ b/src/hooks/lookahead/api.ts
@@ -218,16 +218,16 @@ export async function fetchLookaheadHistory(
   const response = await api.get<unknown>(lookaheadKeys.history(projectId));
   return extractList(response.data, ["history", "snapshots", "items", "data"]).map(
     (entry) => {
-      const rows = Array.isArray(entry.rows)
+      const hasRowsArray = Array.isArray(entry.rows);
+      const rows = hasRowsArray
         ? (entry.rows as LookaheadSnapshotResponse["rows"])
         : [];
       const rowCount =
-        rows.length ||
-        asNumber(entry.row_count) ||
-        asNumber(entry.rows_count) ||
-        asNumber(entry.snapshot_row_count) ||
-        asNumber(entry.count) ||
-        null;
+        asNumber(entry.row_count) ??
+        asNumber(entry.rows_count) ??
+        asNumber(entry.snapshot_row_count) ??
+        asNumber(entry.count) ??
+        (hasRowsArray ? rows.length : null);
 
       return {
         snapshot_id: asOptionalString(entry.snapshot_id) ?? undefined,

--- a/src/hooks/lookahead/api.ts
+++ b/src/hooks/lookahead/api.ts
@@ -217,12 +217,26 @@ export async function fetchLookaheadHistory(
 ): Promise<LookaheadSnapshotHistoryEntry[]> {
   const response = await api.get<unknown>(lookaheadKeys.history(projectId));
   return extractList(response.data, ["history", "snapshots", "items", "data"]).map(
-    (entry) => ({
-      snapshot_id: asOptionalString(entry.snapshot_id) ?? undefined,
-      snapshot_date: asOptionalString(entry.snapshot_date),
-      timezone: asOptionalString(entry.timezone),
-      rows: Array.isArray(entry.rows) ? (entry.rows as LookaheadSnapshotResponse["rows"]) : [],
-    }),
+    (entry) => {
+      const rows = Array.isArray(entry.rows)
+        ? (entry.rows as LookaheadSnapshotResponse["rows"])
+        : [];
+      const rowCount =
+        rows.length ||
+        asNumber(entry.row_count) ||
+        asNumber(entry.rows_count) ||
+        asNumber(entry.snapshot_row_count) ||
+        asNumber(entry.count) ||
+        null;
+
+      return {
+        snapshot_id: asOptionalString(entry.snapshot_id) ?? undefined,
+        snapshot_date: asOptionalString(entry.snapshot_date),
+        timezone: asOptionalString(entry.timezone),
+        rows,
+        row_count: rowCount,
+      };
+    },
   );
 }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -334,6 +334,7 @@ export interface LookaheadSnapshotHistoryEntry {
   snapshot_date?: string | null;
   timezone?: string | null;
   rows: LookaheadRow[];
+  row_count?: number | null;
 }
 
 export interface LookaheadAnomalyFlags {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Retry CTAs and richer empty-state titles/messages for load errors
  * Search, pagination, and card-style review UI with per-item action panels and inline error feedback
  * Snapshot history can reflect and highlight the current snapshot’s row counts

* **Bug Fixes**
  * Improved error handling and clearer load-failure messaging across forecast/diagnostics
  * More robust row-count derivation from diverse history payloads

* **Tests**
  * Added test to preserve summarized snapshot row counts
<!-- end of auto-generated comment: release notes by coderabbit.ai -->